### PR TITLE
fix(docker): scope .dockerignore node_modules to root only

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,8 @@
 .git
 .gitignore
 
-# Dependencies (rebuilt in container)
-node_modules
+# Dependencies (rebuilt in container — root only; workspace node_modules needed by COPY)
+/node_modules
 .venv
 __pycache__
 *.pyc


### PR DESCRIPTION
## Summary
- `.dockerignore` line 6: `node_modules` → `/node_modules` (root-only match)
- The bare pattern matched at any depth, filtering `packages/ui/node_modules` from the build context
- BuildKit failed at `COPY --from=deps /app/packages/ui/node_modules` because the path was excluded

## Test plan
- [ ] CI Docker build passes (was failing with `packages/ui/node_modules not found`)
- [ ] Verify workspace packages still resolve in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)