### PR TITLE
fix: admin skipRemoteAuth + ingestion error handling

### DIFF
--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -29,6 +29,7 @@ const januaConfig = {
     baseURL: process.env.NEXT_PUBLIC_JANUA_BASE_URL || "https://auth.madfam.io",
     apiKey: process.env.NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY || "",
     autoRefreshTokens: true,
+    skipRemoteAuth: true,
 };
 
 export default function RootLayout({

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,7 +11,7 @@
         "test:watch": "vitest"
     },
     "dependencies": {
-        "@janua/nextjs": "^0.1.5",
+        "@janua/nextjs": "^0.1.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@tezca/lib": "*",
         "@tezca/ui": "*",

--- a/apps/api/ingestion_manager.py
+++ b/apps/api/ingestion_manager.py
@@ -32,7 +32,11 @@ class IngestionManager:
     @staticmethod
     def get_status():
         """Read the current ingestion status."""
-        IngestionManager._ensure_paths()
+        try:
+            IngestionManager._ensure_paths()
+        except (PermissionError, OSError) as e:
+            logger.warning("Cannot create data directory: %s", e)
+            # Continue — STATUS_FILE.exists() will return False below
 
         if not STATUS_FILE.exists():
             return {

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -1,3 +1,6 @@
+import logging
+
+from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
@@ -5,6 +8,8 @@ from rest_framework.views import APIView
 
 from .ingestion_manager import IngestionManager
 from .schema import ErrorSchema, IngestionRequestSchema, IngestionResponseSchema
+
+logger = logging.getLogger(__name__)
 
 
 class IngestionView(APIView):
@@ -34,5 +39,13 @@ class IngestionView(APIView):
         responses={200: IngestionResponseSchema},
     )
     def get(self, request):
-        status_data = IngestionManager.get_status()
+        try:
+            status_data = IngestionManager.get_status()
+        except Exception:
+            logger.exception("Failed to get ingestion status")
+            status_data = {
+                "status": "error",
+                "message": "Failed to read ingestion status",
+                "timestamp": timezone.now().isoformat(),
+            }
         return Response(status_data)

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -156,6 +156,27 @@ The admin interface uses the same Janua authentication mechanism but with a sepa
 
 The admin app's environment variables follow the same naming convention (`JANUA_CLIENT_ID`, `JANUA_CLIENT_SECRET`, etc.) but are set to the admin-specific OAuth client values.
 
+### skipRemoteAuth Mode
+
+The admin app sets `skipRemoteAuth: true` in the Janua SDK configuration. This flag prevents the SDK from making direct browser-side API calls to `auth.madfam.io`, which would be CORS-blocked since Janua only allows server-side requests.
+
+When `skipRemoteAuth` is enabled:
+
+- The SDK derives user information from the JWT token stored in `localStorage` (base64-decoded payload) instead of calling `getCurrentUser()` on the remote API.
+- The 60-second auth state polling interval is disabled (no remote auth checks).
+- Token refresh and OAuth callback handling continue to work normally.
+
+This flag is appropriate for apps that manage authentication server-side (e.g., via httpOnly cookies and a `/api/auth/me` proxy route). The admin app uses `AdminAuthBridge` to hydrate the SDK's localStorage from server-side session tokens, so the remote API call is unnecessary.
+
+```typescript
+const januaConfig = {
+    baseURL: "https://auth.madfam.io",
+    apiKey: process.env.NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY,
+    autoRefreshTokens: true,
+    skipRemoteAuth: true, // Prevent CORS-blocked getCurrentUser() calls
+};
+```
+
 ---
 
 ## Reference Implementation

--- a/tests/api/test_ingestion_view.py
+++ b/tests/api/test_ingestion_view.py
@@ -112,6 +112,30 @@ class TestIngestionViewGet:
         assert response.status_code == 200
         assert response.json()["status"] == "error"
 
+    @patch("apps.api.ingestion_manager.IngestionManager.get_status")
+    def test_get_status_exception_returns_error_json(self, mock_status):
+        """GET /ingest/ returns error JSON even when get_status() raises an exception."""
+        mock_status.side_effect = PermissionError("Read-only filesystem")
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "error"
+        assert "Failed to read ingestion status" in data["message"]
+        assert "timestamp" in data
+
+    @patch("apps.api.ingestion_manager.IngestionManager.get_status")
+    def test_get_status_oserror_returns_error_json(self, mock_status):
+        """GET /ingest/ handles OSError from get_status() gracefully."""
+        mock_status.side_effect = OSError("Disk I/O error")
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "error"
+
 
 @pytest.mark.django_db
 class TestIngestionViewPost:


### PR DESCRIPTION
## Summary
- **Admin SDK hydration**: Enable `skipRemoteAuth: true` in Janua config to bypass CORS-blocked `getCurrentUser()` calls. Bumps `@janua/nextjs` to `^0.1.6`.
- **Ingestion 500 fix**: `_ensure_paths()` in `get_status()` threw `PermissionError`/`OSError` when container filesystem is read-only, but was outside the try/except block. Wrapped it + added defense-in-depth handler in `IngestionView.get()`.

## Test plan
- [ ] `admin.tezca.mx` SSO login shows user avatar (SDK hydration works)
- [ ] `GET /api/v1/ingest/` returns `{"status": "idle"}` (not 500)
- [ ] Dashboard API calls include auth headers (no 401s)
- [ ] No CORS errors or polling storms in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)