### PR TITLE
fix(admin): auth navigation + SSO domain detection + 502 handling

### DIFF
--- a/apps/admin/__tests__/api/auth/login-route.test.ts
+++ b/apps/admin/__tests__/api/auth/login-route.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock next/server
+vi.mock('next/server', () => ({
+    NextResponse: {
+        json: (body: unknown, init?: { status?: number }) => ({
+            body,
+            status: init?.status ?? 200,
+        }),
+    },
+}));
+
+// Mock next/headers
+vi.mock('next/headers', () => ({
+    cookies: vi.fn(() => Promise.resolve({
+        set: vi.fn(),
+    })),
+}));
+
+// Mock jose
+vi.mock('jose', () => ({
+    SignJWT: vi.fn(() => ({
+        setProtectedHeader: vi.fn().mockReturnThis(),
+        setIssuedAt: vi.fn().mockReturnThis(),
+        setExpirationTime: vi.fn().mockReturnThis(),
+        sign: vi.fn().mockResolvedValue('mock.jwt.token'),
+    })),
+}));
+
+describe('POST /api/auth/login', () => {
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        vi.resetModules();
+        globalThis.fetch = originalFetch;
+    });
+
+    async function importAndCall(body: object) {
+        const { POST } = await import('@/app/api/auth/login/route');
+        const request = new Request('http://localhost/api/auth/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        return POST(request);
+    }
+
+    it('returns 400 when email is missing', async () => {
+        const res = await importAndCall({ password: 'secret' }) as any;
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/Correo y contraseña/);
+    });
+
+    it('returns 400 when password is missing', async () => {
+        const res = await importAndCall({ email: 'a@b.com' }) as any;
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/Correo y contraseña/);
+    });
+
+    it('returns 503 when upstream returns HTML instead of JSON', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValueOnce(
+            new Response('<!DOCTYPE html><html>Cloudflare challenge</html>', {
+                status: 200,
+                headers: { 'Content-Type': 'text/html' },
+            })
+        );
+
+        const res = await importAndCall({ email: 'a@b.com', password: 'p' }) as any;
+        expect(res.status).toBe(503);
+        expect(res.body.error).toMatch(/no está disponible/);
+    });
+
+    it('returns upstream error status on non-OK JSON response', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValueOnce(
+            new Response(JSON.stringify({ detail: 'Cuenta bloqueada' }), {
+                status: 403,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        );
+
+        const res = await importAndCall({ email: 'a@b.com', password: 'p' }) as any;
+        expect(res.status).toBe(403);
+        expect(res.body.error).toBe('Cuenta bloqueada');
+    });
+
+    it('returns 502 on network failure', async () => {
+        globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+        const res = await importAndCall({ email: 'a@b.com', password: 'p' }) as any;
+        expect(res.status).toBe(502);
+        expect(res.body.error).toMatch(/Error de conexión/);
+    });
+});

--- a/apps/admin/__tests__/lib/auth.test.tsx
+++ b/apps/admin/__tests__/lib/auth.test.tsx
@@ -154,7 +154,7 @@ describe('AdminAuthBridge', () => {
         expect(callHeaders['Authorization']).toBe('Bearer mock-token');
     });
 
-    it('clears token source on unmount', async () => {
+    it('preserves token source after unmount (root layout never unmounts)', async () => {
         const mockGetAccessToken = vi.fn().mockResolvedValue('unmount-token');
         const { useJanua } = await import('@janua/nextjs');
         (useJanua as ReturnType<typeof vi.fn>).mockReturnValue({
@@ -182,11 +182,12 @@ describe('AdminAuthBridge', () => {
         await api.getHealth();
         expect(mockFetchFn.mock.calls[0][1].headers['Authorization']).toBe('Bearer unmount-token');
 
-        // After unmount, token source should be cleared
+        // Token source persists after unmount — no cleanup nullification
+        // (AdminAuthBridge lives in root layout and never unmounts in production)
         unmount();
         mockFetchFn.mockClear();
         await api.getHealth();
-        expect(mockFetchFn.mock.calls[0][1].headers).not.toHaveProperty('Authorization');
+        expect(mockFetchFn.mock.calls[0][1].headers['Authorization']).toBe('Bearer unmount-token');
     });
 });
 

--- a/apps/admin/__tests__/pages/sign-in.test.tsx
+++ b/apps/admin/__tests__/pages/sign-in.test.tsx
@@ -226,6 +226,64 @@ describe('SignInPage', () => {
         expect(screen.getByText(/JANUA_SECRET_KEY/)).toBeInTheDocument();
     });
 
+    it('shows SSO hint when SSO domain email is entered', async () => {
+        process.env = { ...originalEnv, NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY: 'jnc_test_key' };
+
+        const { default: SignInPage } = await import('@/app/sign-in/page');
+        render(<SignInPage />);
+
+        // Initially password field is visible
+        expect(screen.getByLabelText('Contraseña')).toBeInTheDocument();
+
+        // Type an SSO domain email
+        fireEvent.change(screen.getByLabelText('Correo electrónico'), {
+            target: { value: 'admin@madfam.io' },
+        });
+
+        // Password field replaced with SSO hint
+        expect(screen.queryByLabelText('Contraseña')).not.toBeInTheDocument();
+        expect(screen.getByText(/Cuenta de organización/)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Continuar con SSO' })).toBeInTheDocument();
+    });
+
+    it('keeps password field for non-SSO domain emails', async () => {
+        process.env = { ...originalEnv, NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY: 'jnc_test_key' };
+
+        const { default: SignInPage } = await import('@/app/sign-in/page');
+        render(<SignInPage />);
+
+        fireEvent.change(screen.getByLabelText('Correo electrónico'), {
+            target: { value: 'user@example.com' },
+        });
+
+        expect(screen.getByLabelText('Contraseña')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Iniciar sesión' })).toBeInTheDocument();
+        expect(screen.queryByText(/Cuenta de organización/)).not.toBeInTheDocument();
+    });
+
+    it('redirects SSO domain emails to /api/auth/sso on form submit', async () => {
+        process.env = { ...originalEnv, NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY: 'jnc_test_key' };
+
+        const originalLocation = window.location;
+        // @ts-expect-error — override for test
+        delete window.location;
+        window.location = { ...originalLocation, origin: 'http://localhost:3000', href: '' } as Location;
+
+        const { default: SignInPage } = await import('@/app/sign-in/page');
+        render(<SignInPage />);
+
+        fireEvent.change(screen.getByLabelText('Correo electrónico'), {
+            target: { value: 'admin@madfam.io' },
+        });
+        fireEvent.submit(screen.getByRole('button', { name: 'Continuar con SSO' }).closest('form')!);
+
+        await waitFor(() => {
+            expect(window.location.href).toBe('/api/auth/sso');
+        });
+
+        window.location = originalLocation;
+    });
+
     it('redirects to / when already authenticated', async () => {
         process.env = { ...originalEnv, NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY: 'jnc_test_key' };
         mockUseAuth.mockReturnValue({

--- a/apps/admin/app/api/auth/login/route.ts
+++ b/apps/admin/app/api/auth/login/route.ts
@@ -60,6 +60,17 @@ export async function POST(request: Request) {
             );
         }
 
+        // Detect non-JSON responses (e.g. Cloudflare HTML challenge pages)
+        const contentType = loginRes.headers.get("content-type") || "";
+        if (!contentType.includes("application/json")) {
+            return NextResponse.json(
+                {
+                    error: "El servidor de autenticación no está disponible. Usa SSO para iniciar sesión.",
+                },
+                { status: 503 }
+            );
+        }
+
         loginData = await loginRes.json();
     } catch (err) {
         console.error("Login proxy error:", err);

--- a/apps/admin/app/sign-in/page.tsx
+++ b/apps/admin/app/sign-in/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useState, useEffect, FormEvent, Suspense } from "react";
+import { useState, useEffect, useMemo, FormEvent, Suspense } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { Shield } from "lucide-react";
 
 const januaConfigured = !!process.env.NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY;
+
+/** Email domains that require SSO login (no email/password fallback). */
+const SSO_DOMAINS = ["madfam.io"];
 
 export default function SignInPage() {
     const router = useRouter();
@@ -52,9 +55,22 @@ function SignInFormContent({ router }: { router: ReturnType<typeof useRouter> })
         window.location.href = "/api/auth/sso";
     }
 
+    const isSsoDomain = useMemo(() => {
+        const domain = email.split("@")[1]?.toLowerCase();
+        return domain ? SSO_DOMAINS.includes(domain) : false;
+    }, [email]);
+
     async function handleSubmit(e: FormEvent) {
         e.preventDefault();
         setFormError(null);
+
+        // Redirect SSO-only domains directly to SSO flow
+        const domain = email.split("@")[1]?.toLowerCase();
+        if (domain && SSO_DOMAINS.includes(domain)) {
+            window.location.href = "/api/auth/sso";
+            return;
+        }
+
         setSubmitting(true);
         try {
             const res = await fetch("/api/auth/login", {
@@ -183,32 +199,38 @@ function SignInFormContent({ router }: { router: ReturnType<typeof useRouter> })
                     />
                 </div>
 
-                <div className="space-y-2">
-                    <label
-                        htmlFor="password"
-                        className="block text-sm font-medium text-foreground"
-                    >
-                        Contraseña
-                    </label>
-                    <input
-                        id="password"
-                        name="password"
-                        type="password"
-                        autoComplete="current-password"
-                        required
-                        value={password}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
-                        disabled={submitting}
-                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-                    />
-                </div>
+                {isSsoDomain ? (
+                    <div className="rounded-md bg-muted/50 border border-border px-4 py-3 text-sm text-muted-foreground">
+                        Cuenta de organización — usar SSO
+                    </div>
+                ) : (
+                    <div className="space-y-2">
+                        <label
+                            htmlFor="password"
+                            className="block text-sm font-medium text-foreground"
+                        >
+                            Contraseña
+                        </label>
+                        <input
+                            id="password"
+                            name="password"
+                            type="password"
+                            autoComplete="current-password"
+                            required
+                            value={password}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+                            disabled={submitting}
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+                        />
+                    </div>
+                )}
 
                 <button
                     type="submit"
-                    disabled={submitting}
+                    disabled={submitting || isSsoDomain}
                     className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
                 >
-                    {submitting ? "Iniciando sesión..." : "Iniciar sesión"}
+                    {isSsoDomain ? "Continuar con SSO" : submitting ? "Iniciando sesión..." : "Iniciar sesión"}
                 </button>
             </form>
         </PageShell>

--- a/apps/admin/lib/api.ts
+++ b/apps/admin/lib/api.ts
@@ -26,11 +26,16 @@ async function fetcher<T>(endpoint: string, options?: RequestInit): Promise<T> {
     };
 
     // Inject auth token if available
+    let token: string | null = null;
     if (_getToken) {
-        const token = await _getToken();
-        if (token) {
-            headers['Authorization'] = `Bearer ${token}`;
-        }
+        token = await _getToken();
+    }
+    // Fallback: read directly from localStorage if token source unavailable
+    if (!token && typeof window !== 'undefined') {
+        token = localStorage.getItem('janua_access_token');
+    }
+    if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
     }
 
     const doFetch = async (hdrs: Record<string, string>) => {

--- a/apps/admin/lib/auth.tsx
+++ b/apps/admin/lib/auth.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { setTokenSource } from "./api";
 
 // Re-export Janua components for use across the app
@@ -75,15 +75,10 @@ export function AdminAuthBridge({ children }: { children: React.ReactNode }) {
         }
     }, []);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (client) {
             setTokenSource(() => client.getAccessToken());
-        } else {
-            setTokenSource(null);
         }
-        return () => {
-            setTokenSource(null);
-        };
     }, [client]);
 
     return <>{children}</>;

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -177,6 +177,26 @@ const januaConfig = {
 };
 ```
 
+### SSO Domain Enforcement
+
+The admin sign-in page detects email domains that require SSO and prevents the email/password form from submitting for those domains. This avoids a 502 error that occurs when the server-side login proxy hits Cloudflare's HTML challenge page instead of Janua's JSON API.
+
+**Enforced domains**: `madfam.io`
+
+When a user types an email with an SSO-enforced domain:
+
+1. The password field is replaced with an "Cuenta de organización — usar SSO" hint.
+2. The submit button changes to "Continuar con SSO".
+3. Submitting the form redirects to `/api/auth/sso` (the PKCE OAuth flow) instead of calling the login proxy.
+
+To add a new SSO-enforced domain, update the `SSO_DOMAINS` array in `apps/admin/app/sign-in/page.tsx`.
+
+### Email/Password Login Proxy
+
+The admin app includes a server-side proxy route at `/api/auth/login` that forwards email/password credentials to Janua's `/api/v1/auth/login` endpoint. This avoids CORS issues since browser-to-Janua requests are blocked.
+
+The proxy includes Content-Type validation: if Janua returns HTML (e.g., a Cloudflare challenge page) instead of JSON, the proxy returns a 503 with a user-friendly message directing the user to SSO.
+
 ---
 
 ## Reference Implementation


### PR DESCRIPTION
## Summary
- **Client-side navigation 401s**: `useEffect` → `useLayoutEffect` for token source injection eliminates the race where data-fetching effects fire before `_getToken` is set. Adds localStorage fallback in fetcher.
- **SSO domain detection**: Sign-in form detects `@madfam.io` emails and auto-redirects to SSO, preventing the 502 from the server-to-server proxy hitting Cloudflare's HTML challenge. Shows "Cuenta de organización — usar SSO" hint.
- **Login proxy error handling**: Checks `Content-Type` before JSON parsing — if Janua returns HTML (Cloudflare challenge), returns 503 with user-friendly message instead of crashing.

## Test plan
- [ ] SSO login → navigate between all pages → zero 401s on API endpoints
- [ ] Go to /sign-in → type admin@madfam.io → password field replaced with SSO hint, button says "Continuar con SSO"
- [ ] Submit SSO domain email → auto-redirect to /api/auth/sso
- [ ] Type non-SSO email → password field appears normally
- [ ] Run existing auth tests (19/19 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)