### PR TITLE
fix(netpolicy): add enclii.dev/type label for janua ingress

### DIFF
--- a/k8s/production/namespace.yaml
+++ b/k8s/production/namespace.yaml
@@ -4,3 +4,4 @@ metadata:
   name: tezca
   labels:
     app.kubernetes.io/part-of: tezca
+    enclii.dev/type: application


### PR DESCRIPTION
## Summary
- Add `enclii.dev/type: application` label to tezca namespace
- Required by `janua-api-ingress` NetworkPolicy's `namespaceSelector` to allow cross-namespace traffic
- Without this label, server-side SSO calls from tezca-admin to janua-api are blocked

## Test plan
- [ ] `kubectl apply -f k8s/production/namespace.yaml` — label applied
- [ ] `kubectl get ns tezca --show-labels` — verify `enclii.dev/type=application` present
- [ ] Test admin.tezca.mx login proxy (no more 502 from NetworkPolicy block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)