### PR TITLE
chore: apply black + isort to drifted files (unblocks CI)

### DIFF
--- a/apps/api/billing_stream_consumer.py
+++ b/apps/api/billing_stream_consumer.py
@@ -52,7 +52,9 @@ PLAN_TO_TIER = {
 
 def _get_redis_client():
     """Create a synchronous Redis client from REDIS_URL."""
-    url = os.environ.get("REDIS_URL", os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0"))
+    url = os.environ.get(
+        "REDIS_URL", os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
+    )
     return redis.Redis.from_url(url, decode_responses=True)
 
 
@@ -111,9 +113,9 @@ def _on_subscription_created(data):
         )
         return
 
-    updated = APIKey.objects.filter(
-        janua_user_id=user_id, is_active=True
-    ).update(tier=new_tier)
+    updated = APIKey.objects.filter(janua_user_id=user_id, is_active=True).update(
+        tier=new_tier
+    )
 
     logger.info(
         "Billing stream: subscription created user=%s plan=%s tier=%s keys_updated=%d",
@@ -132,9 +134,9 @@ def _on_subscription_cancelled(data):
     if not user_id:
         return
 
-    updated = APIKey.objects.filter(
-        janua_user_id=user_id, is_active=True
-    ).update(tier="free_member")
+    updated = APIKey.objects.filter(janua_user_id=user_id, is_active=True).update(
+        tier="free_member"
+    )
 
     logger.info(
         "Billing stream: subscription cancelled user=%s reason=%s keys_updated=%d",
@@ -239,9 +241,7 @@ def poll_billing_events():
                 errors += 1
                 continue
 
-            event_type = event_data.get(
-                "event_type", event_data.get("type", "")
-            )
+            event_type = event_data.get("event_type", event_data.get("type", ""))
 
             try:
                 _process_event(event_type, event_data)
@@ -254,9 +254,7 @@ def poll_billing_events():
                     pending = client.xpending_range(
                         STREAM_KEY, GROUP_NAME, msg_id, msg_id, 1
                     )
-                    retry_count = (
-                        pending[0].get("times_delivered", 0) if pending else 0
-                    )
+                    retry_count = pending[0].get("times_delivered", 0) if pending else 0
                 except Exception:
                     retry_count = MAX_RETRIES  # Assume exhausted on error
 

--- a/apps/api/management/commands/index_laws.py
+++ b/apps/api/management/commands/index_laws.py
@@ -487,7 +487,9 @@ class Command(BaseCommand):
             # Add embedding if generator is available
             if embedding_generator and art["text"]:
                 try:
-                    doc["_source"]["text_embedding"] = embedding_generator.generate(art["text"])
+                    doc["_source"]["text_embedding"] = embedding_generator.generate(
+                        art["text"]
+                    )
                 except Exception:
                     pass  # Skip embedding on failure, article is still indexed
 
@@ -599,6 +601,7 @@ class Command(BaseCommand):
         if options.get("with_embeddings"):
             try:
                 from apps.parsers.embeddings import EmbeddingGenerator
+
                 embedding_generator = EmbeddingGenerator()
                 self.stdout.write(
                     self.style.SUCCESS(

--- a/apps/api/middleware/janua_auth.py
+++ b/apps/api/middleware/janua_auth.py
@@ -30,7 +30,9 @@ def _get_jwks():
         if _jwks_cache["keys"] and (now - _jwks_cache["fetched_at"]) < JWKS_CACHE_TTL:
             return _jwks_cache["keys"]
 
-    base_url = getattr(settings, "JANUA_ISSUER_URL", "") or getattr(settings, "JANUA_BASE_URL", "")
+    base_url = getattr(settings, "JANUA_ISSUER_URL", "") or getattr(
+        settings, "JANUA_BASE_URL", ""
+    )
     if not base_url:
         raise AuthenticationFailed(
             "Janua auth is not configured (JANUA_ISSUER_URL missing)"
@@ -119,7 +121,9 @@ class JanuaJWTAuthentication(BaseAuthentication):
 
         public_key = _get_public_key(token)
         audience = getattr(settings, "JANUA_AUDIENCE", "tezca-api")
-        issuer = getattr(settings, "JANUA_ISSUER_URL", "") or getattr(settings, "JANUA_BASE_URL", "")
+        issuer = getattr(settings, "JANUA_ISSUER_URL", "") or getattr(
+            settings, "JANUA_BASE_URL", ""
+        )
 
         try:
             claims = jwt.decode(

--- a/apps/api/search_views.py
+++ b/apps/api/search_views.py
@@ -350,9 +350,7 @@ class SearchView(APIView):
                     {
                         "id": hit["_id"],
                         "law_id": source.get("law_id"),
-                        "law_name": source.get(
-                            "law_name", source.get("law_id")
-                        ),
+                        "law_name": source.get("law_name", source.get("law_id")),
                         "article": f"Art. {source.get('article', source.get('article_id'))}",
                         "snippet": highlight,
                         "text": raw_text,

--- a/apps/api/semantic_search_views.py
+++ b/apps/api/semantic_search_views.py
@@ -42,7 +42,9 @@ def semantic_search(request):
         query_embedding = generator.generate(query)
     except ImportError:
         return Response(
-            {"error": "Semantic search is not available — embedding model not installed"},
+            {
+                "error": "Semantic search is not available — embedding model not installed"
+            },
             status=503,
         )
     except Exception as e:

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -21,7 +21,6 @@ from .admin_views import (
 from .analytics_views import search_analytics
 from .annotation_views import annotation_detail, annotation_list
 from .apikey_views import create_api_key, list_api_keys, revoke_api_key, update_api_key
-from .user_apikey_views import user_apikey_list_create, user_apikey_update, user_apikey_revoke
 from .billing_views import billing_webhook
 from .bulk_views import bulk_articles
 from .changelog_views import changelog
@@ -46,6 +45,7 @@ from .export_views import (
     export_txt,
 )
 from .graph_views import graph_overview, graph_public_showcase, law_graph
+from .interest_views import register_interest
 from .judicial_views import (
     judicial_detail,
     judicial_list,
@@ -68,7 +68,6 @@ from .law_views import (
 )
 from .middleware.admin_permission import IsTezcaAdmin
 from .middleware.janua_auth import JanuaJWTAuthentication
-from .interest_views import register_interest
 from .newsletter_views import newsletter_subscribe, newsletter_unsubscribe
 from .notification_views import (
     alert_delete,
@@ -81,6 +80,11 @@ from .resolve_views import resolve
 from .search_views import SearchView
 from .semantic_search_views import semantic_search
 from .trial_views import trial_start, trial_status
+from .user_apikey_views import (
+    user_apikey_list_create,
+    user_apikey_revoke,
+    user_apikey_update,
+)
 from .views import IngestionView
 from .webhook_views import create_webhook, delete_webhook, list_webhooks, test_webhook
 

--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -182,7 +182,9 @@ if not DEBUG:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # ── Janua Auth ────────────────────────────────────────────────────────
-JANUA_ISSUER_URL = os.environ.get("JANUA_ISSUER_URL", "") or os.environ.get("JANUA_BASE_URL", "")
+JANUA_ISSUER_URL = os.environ.get("JANUA_ISSUER_URL", "") or os.environ.get(
+    "JANUA_BASE_URL", ""
+)
 JANUA_BASE_URL = JANUA_ISSUER_URL  # backwards compat alias
 JANUA_AUDIENCE = os.environ.get("JANUA_AUDIENCE", "tezca-api")
 

--- a/apps/parsers/pipeline.py
+++ b/apps/parsers/pipeline.py
@@ -482,8 +482,7 @@ class IngestionPipeline:
                 print(f"   📷 Extracted via OCR ({len(full_text):,} chars)")
             else:
                 print(
-                    "   ⚠️  OCR did not improve extraction, "
-                    "keeping pdfplumber result"
+                    "   ⚠️  OCR did not improve extraction, " "keeping pdfplumber result"
                 )
 
         return full_text
@@ -590,8 +589,7 @@ class IngestionPipeline:
             from pdf2image import convert_from_path
         except ImportError:
             print(
-                "   ⚠️  pdf2image not installed — "
-                "install with: pip install pdf2image"
+                "   ⚠️  pdf2image not installed — " "install with: pip install pdf2image"
             )
             return ""
 

--- a/apps/scraper/client/madfam_bridge.py
+++ b/apps/scraper/client/madfam_bridge.py
@@ -14,70 +14,73 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+
 class MadfamBridge:
     def __init__(self, endpoint: str = "http://madfam-crawler:8000/v1/crawl"):
         self.endpoint = endpoint
         self.poll_interval = 5.0  # seconds
-    
+
     def extract_sync(
-        self, 
-        url: str, 
-        extraction_prompt: str, 
+        self,
+        url: str,
+        extraction_prompt: str,
         schema_definition: Dict[str, Any],
-        timeout: float = 60.0
+        timeout: float = 60.0,
     ) -> Optional[Dict[str, Any]]:
         """Synchronous extraction method for legacy block-based scrapers."""
         payload = {
             "url": url,
             "extraction_prompt": extraction_prompt,
             "schema_definition": schema_definition,
-            "source_app": "tezca"
+            "source_app": "tezca",
         }
-        
+
         with httpx.Client(timeout=10.0) as client:
             try:
                 logger.info(f"[MadfamBridge] Enqueueing scrape for {url}")
                 response = client.post(self.endpoint, json=payload)
                 if response.status_code != 202:
-                    logger.error(f"[MadfamBridge] Broker rejected task. HTTP {response.status_code}")
+                    logger.error(
+                        f"[MadfamBridge] Broker rejected task. HTTP {response.status_code}"
+                    )
                     return None
-                    
+
                 task_id = response.json().get("task_id")
                 logger.info(f"[MadfamBridge] Task {task_id} received. Polling...")
-                
+
                 elapsed = 0.0
                 while elapsed < timeout:
                     status_resp = client.get(f"{self.endpoint}/{task_id}")
                     if status_resp.status_code == 200:
                         data = status_resp.json()
                         status = data.get("status")
-                        
+
                         if status == "SUCCESS":
                             return data.get("result", {}).get("structured_data", {})
                         elif status == "FAILURE":
                             return None
-                    
+
                     time.sleep(self.poll_interval)
                     elapsed += self.poll_interval
-                    
+
                 return None
             except Exception as e:
                 logger.error(f"[MadfamBridge] Communication error: {e}", exc_info=True)
                 return None
 
     async def extract(
-        self, 
-        url: str, 
-        extraction_prompt: str, 
+        self,
+        url: str,
+        extraction_prompt: str,
         schema_definition: Dict[str, Any],
-        timeout: float = 60.0
+        timeout: float = 60.0,
     ) -> Optional[Dict[str, Any]]:
         """Delegates LLM extraction to madfam-crawler."""
         payload = {
             "url": url,
             "extraction_prompt": extraction_prompt,
             "schema_definition": schema_definition,
-            "source_app": "tezca"
+            "source_app": "tezca",
         }
 
         async with httpx.AsyncClient(timeout=10.0) as client:
@@ -86,34 +89,40 @@ class MadfamBridge:
                 logger.info(f"[MadfamBridge] Enqueueing scrape for {url}")
                 response = await client.post(self.endpoint, json=payload)
                 if response.status_code != 202:
-                    logger.error(f"[MadfamBridge] Broker rejected task. HTTP {response.status_code} - {response.text}")
+                    logger.error(
+                        f"[MadfamBridge] Broker rejected task. HTTP {response.status_code} - {response.text}"
+                    )
                     return None
-                    
+
                 task_id = response.json().get("task_id")
-                
+
                 # 2. Poll
                 logger.info(f"[MadfamBridge] Task {task_id} received. Polling...")
-                
+
                 elapsed = 0.0
                 while elapsed < timeout:
                     status_resp = await client.get(f"{self.endpoint}/{task_id}")
                     if status_resp.status_code == 200:
                         data = status_resp.json()
                         status = data.get("status")
-                        
+
                         if status == "SUCCESS":
                             logger.info(f"[MadfamBridge] Scrape completed for {url}")
                             return data.get("result", {}).get("structured_data", {})
                         elif status == "FAILURE":
-                            logger.error(f"[MadfamBridge] Worker failed task {task_id}: {data.get('error')}")
+                            logger.error(
+                                f"[MadfamBridge] Worker failed task {task_id}: {data.get('error')}"
+                            )
                             return None
-                    
+
                     await asyncio.sleep(self.poll_interval)
                     elapsed += self.poll_interval
-                    
-                logger.error(f"[MadfamBridge] Task {task_id} timed out after {timeout}s.")
+
+                logger.error(
+                    f"[MadfamBridge] Task {task_id} timed out after {timeout}s."
+                )
                 return None
-                
+
             except Exception as e:
                 logger.error(f"[MadfamBridge] Communication error: {e}", exc_info=True)
                 return None

--- a/apps/scraper/federal/rmf_scraper.py
+++ b/apps/scraper/federal/rmf_scraper.py
@@ -24,7 +24,9 @@ logger = logging.getLogger(__name__)
 # SAT RMF Source URLs
 # ---------------------------------------------------------------------------
 
-SAT_RMF_BASE = "https://www.sat.gob.mx/normatividad/22702/resoluciones-miscelaneas-fiscales"
+SAT_RMF_BASE = (
+    "https://www.sat.gob.mx/normatividad/22702/resoluciones-miscelaneas-fiscales"
+)
 SAT_RMF_ANNEXES = "https://www.sat.gob.mx/normatividad/22703/anexos-de-la-resolucion-miscelanea-fiscal"
 
 

--- a/apps/scraper/judicial/scjn_playwright.py
+++ b/apps/scraper/judicial/scjn_playwright.py
@@ -37,9 +37,9 @@ from typing import Any, Dict, List, Optional
 
 from playwright.sync_api import TimeoutError as PlaywrightTimeout
 
+from apps.scraper.client.madfam_bridge import MadfamBridge
 from apps.scraper.judicial.scjn_scraper import EPOCAS, ScjnScraper
 from apps.scraper.playwright_base import PlaywrightBase
-from apps.scraper.client.madfam_bridge import MadfamBridge
 
 logger = logging.getLogger(__name__)
 
@@ -498,15 +498,15 @@ class ScjnPlaywrightScraper(PlaywrightBase):
 
     def _fetch_detail_page(self, registro: str) -> Dict[str, str]:
         """Fetch and parse a single SJF detail page for full record fields.
-        
+
         Delegates the immense layout inconsistencies and Regex requirements entirely
         to madfam-crawler, which returns standard JSON structured_data immediately.
         """
         url = f"{SJF_DETAIL_URL}/{registro}"
-        
+
         logger.info(f"Delegating detail extraction to madfam-crawler for {url}")
         prompt = "Extract the specific case details, identifying metadata like materia, tesis, instancia, ponente, and tipo. Capture the 'rubro' (the title/summary paragraph) and the core legal 'texto' body."
-        
+
         schema = {
             "materia": "str",
             "tesis_num": "str",
@@ -514,19 +514,18 @@ class ScjnPlaywrightScraper(PlaywrightBase):
             "ponente": "str",
             "tipo_tesis": "str",
             "rubro": "str",
-            "texto": "str"
+            "texto": "str",
         }
-        
+
         result = self.madfam.extract_sync(
-            url=url,
-            extraction_prompt=prompt,
-            schema_definition=schema,
-            timeout=120.0
+            url=url, extraction_prompt=prompt, schema_definition=schema, timeout=120.0
         )
-        
-        if result and "tesis" in result: # Map potential 'tesis' key back to original expected 'tesis_num' 
+
+        if (
+            result and "tesis" in result
+        ):  # Map potential 'tesis' key back to original expected 'tesis_num'
             result["tesis_num"] = result.pop("tesis")
-            
+
         return result if result else {}
 
     def _enrich_records(self, records: List[Dict]) -> List[Dict]:

--- a/scripts/validation/verify_system.py
+++ b/scripts/validation/verify_system.py
@@ -31,9 +31,7 @@ def verify_system():
         print(f"   found {len(laws)} laws registered in DB.")
         print(f"   sample: {laws[0]['id']} ({laws[0]['versions']} versions)")
     else:
-        print(
-            "   ⚠️ No laws found in DB list (might be expected if ingestion is fresh)"
-        )
+        print("   ⚠️ No laws found in DB list (might be expected if ingestion is fresh)")
 
     # 2. Test Law Detail (Amparo)
     law_id = "amparo"

--- a/tests/api/test_newsletter_views.py
+++ b/tests/api/test_newsletter_views.py
@@ -109,7 +109,11 @@ class TestNewsletterSubscribe:
         with patch("apps.api.crm_sync.dispatch_crm_event") as mock_dispatch:
             response = self.client.post(
                 self.url,
-                {"email": "crm@example.com", "topics": topics, "source_page": "bienvenida"},
+                {
+                    "email": "crm@example.com",
+                    "topics": topics,
+                    "source_page": "bienvenida",
+                },
                 format="json",
             )
 

--- a/tests/api/test_resolve_views.py
+++ b/tests/api/test_resolve_views.py
@@ -24,7 +24,6 @@ from rest_framework.test import APIClient
 
 from apps.api.models import JudicialRecord
 
-
 # ── Helpers ───────────────────────────────────────────────────────────
 
 
@@ -191,7 +190,15 @@ class TestResolveValidQuery:
 
         data = response.json()
         art = data["articles"][0]
-        expected_fields = {"law_id", "law_name", "article", "snippet", "score", "tier", "domains"}
+        expected_fields = {
+            "law_id",
+            "law_name",
+            "article",
+            "snippet",
+            "score",
+            "tier",
+            "domains",
+        }
         assert expected_fields.issubset(set(art.keys()))
 
     @patch("apps.api.resolve_views.es_client")
@@ -270,12 +277,14 @@ class TestResolveDomainFiltering:
         mock_es.search.return_value = _build_es_response([])
 
         # Create records with different materias
-        _create_judicial_record(query_term="despido", materia="laboral", uid_suffix="lab1")
-        _create_judicial_record(query_term="despido", materia="civil", uid_suffix="civ1")
-
-        response = self.client.get(
-            self.url, {"q": "despido", "domain": "laboral"}
+        _create_judicial_record(
+            query_term="despido", materia="laboral", uid_suffix="lab1"
         )
+        _create_judicial_record(
+            query_term="despido", materia="civil", uid_suffix="civ1"
+        )
+
+        response = self.client.get(self.url, {"q": "despido", "domain": "laboral"})
 
         data = response.json()
         # Only the laboral record should appear
@@ -288,7 +297,9 @@ class TestResolveDomainFiltering:
         mock_es.ping.return_value = True
         mock_es.search.return_value = _build_es_response([])
 
-        _create_judicial_record(query_term="constitucion", materia="civil", uid_suffix="nd1")
+        _create_judicial_record(
+            query_term="constitucion", materia="civil", uid_suffix="nd1"
+        )
         _create_judicial_record(
             query_term="constitucion", materia="constitucional", uid_suffix="nd2"
         )

--- a/tests/api/test_semantic_search.py
+++ b/tests/api/test_semantic_search.py
@@ -79,12 +79,18 @@ class TestSemanticSearch:
         mock_embeddings_module.EmbeddingGenerator.return_value = mock_generator
 
         hits = [
-            _make_semantic_hit("cpeum-1", "cpeum", "1", "La soberania nacional reside en el pueblo."),
-            _make_semantic_hit("cff-5", "cff", "5", "Son contribuciones los impuestos.", score=0.88),
+            _make_semantic_hit(
+                "cpeum-1", "cpeum", "1", "La soberania nacional reside en el pueblo."
+            ),
+            _make_semantic_hit(
+                "cff-5", "cff", "5", "Son contribuciones los impuestos.", score=0.88
+            ),
         ]
         mock_es.search.return_value = {"hits": {"hits": hits}}
 
-        with patch.dict(sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}):
+        with patch.dict(
+            sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}
+        ):
             response = self.client.get(self.url, {"q": "soberania del pueblo"})
 
         assert response.status_code == 200
@@ -126,7 +132,9 @@ class TestSemanticSearch:
 
         mock_es.search.return_value = {"hits": {"hits": []}}
 
-        with patch.dict(sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}):
+        with patch.dict(
+            sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}
+        ):
             response = self.client.get(self.url, {"q": "test", "limit": "5"})
 
         assert response.status_code == 200
@@ -148,7 +156,9 @@ class TestSemanticSearch:
 
         mock_es.search.return_value = {"hits": {"hits": []}}
 
-        with patch.dict(sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}):
+        with patch.dict(
+            sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}
+        ):
             response = self.client.get(self.url, {"q": "test", "limit": "200"})
 
         assert response.status_code == 200
@@ -180,7 +190,9 @@ class TestSemanticSearch:
             message="Connection refused", meta=MagicMock(), body=None
         )
 
-        with patch.dict(sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}):
+        with patch.dict(
+            sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}
+        ):
             response = self.client.get(self.url, {"q": "impuestos"})
 
         assert response.status_code == 503
@@ -195,7 +207,9 @@ class TestSemanticSearch:
         mock_embeddings_module = MagicMock()
         mock_embeddings_module.EmbeddingGenerator.return_value = mock_generator
 
-        with patch.dict(sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}):
+        with patch.dict(
+            sys.modules, {"apps.parsers.embeddings": mock_embeddings_module}
+        ):
             response = self.client.get(self.url, {"q": "derechos humanos"})
 
         assert response.status_code == 500

--- a/tests/pipeline/test_index_laws.py
+++ b/tests/pipeline/test_index_laws.py
@@ -253,9 +253,9 @@ class TestIndexLawsCommand:
 
             assert len(actions) == 2
             for doc in actions:
-                assert "text_embedding" in doc["_source"], (
-                    f"Article {doc['_id']} missing text_embedding"
-                )
+                assert (
+                    "text_embedding" in doc["_source"]
+                ), f"Article {doc['_id']} missing text_embedding"
                 assert doc["_source"]["text_embedding"] == fake_vector
                 assert len(doc["_source"]["text_embedding"]) == 768
 
@@ -301,9 +301,9 @@ class TestIndexLawsCommand:
             actions = article_call_args[0][1]
 
             for doc in actions:
-                assert "text_embedding" not in doc["_source"], (
-                    f"Article {doc['_id']} should not have text_embedding"
-                )
+                assert (
+                    "text_embedding" not in doc["_source"]
+                ), f"Article {doc['_id']} should not have text_embedding"
 
     def test_embedding_failure_skips_gracefully(self, command):
         """When embedding generation fails for an article, it is still indexed without embedding."""


### PR DESCRIPTION
Pure formatter output (black + isort --profile=black) on 16 files that drifted on main. No semantic change. Unblocks Backend Tests (Python 3.11 / 3.12) on every PR — they've been failing at `Lint with black (check)`. Same pattern as enclii #78 for gofmt. 🤖 Claude Code