### PR TITLE
fix(scraper): route verify=False through INSECURE_HOSTS allowlist [AUDIT H7]

### DIFF
--- a/apps/scraper/federal/nom_scraper.py
+++ b/apps/scraper/federal/nom_scraper.py
@@ -269,8 +269,26 @@ class NomScraper:
                 "Accept-Language": "es-MX,es;q=0.9,en;q=0.5",
             }
         )
-        # DOF has chronic SSL certificate issues — disable verification
-        session.verify = False
+        # Audit 2026-04-23 H7: route verify=False decisions through the
+        # centralized INSECURE_HOSTS allowlist in apps/scraper/http.py
+        # rather than blanket-disabling for the whole session. Callers
+        # that hit dof.gob.mx (the DOF host currently in the allowlist)
+        # will still get verify=False per allowlist rule; callers that
+        # accidentally route elsewhere now get proper TLS verification.
+        from apps.scraper.http import INSECURE_HOSTS
+        from urllib.parse import urlparse
+
+        def _pick_verify(url: str | bytes) -> bool:
+            host = urlparse(url if isinstance(url, str) else url.decode()).hostname or ""
+            return host not in INSECURE_HOSTS
+
+        _original_request = session.request
+
+        def _request_with_allowlist(method, url, **kwargs):
+            kwargs.setdefault("verify", _pick_verify(url))
+            return _original_request(method, url, **kwargs)
+
+        session.request = _request_with_allowlist  # type: ignore[assignment]
         return session
 
     def _rate_limit(self) -> None:

--- a/apps/scraper/http.py
+++ b/apps/scraper/http.py
@@ -38,6 +38,9 @@ INSECURE_HOSTS: frozenset[str] = frozenset(
         "cnartys.conamer.gob.mx",
         "tratados.sre.gob.mx",
         "sjf.scjn.gob.mx",
+        # pnt_scraper.py downloads PDFs from the Plataforma Nacional de
+        # Transparencia; its certificate chain has been chronically broken.
+        "consultapublica.plataformadetransparencia.org.mx",
     }
 )
 

--- a/apps/scraper/municipal/pnt_scraper.py
+++ b/apps/scraper/municipal/pnt_scraper.py
@@ -601,7 +601,13 @@ class PNTMunicipalScraper(MunicipalScraper):
         if self.is_pdf(url):
             try:
                 self._rate_limit()
-                response = self.session.get(url, timeout=120, verify=False)
+                # Audit 2026-04-23 H7: defer TLS verification to the
+                # session-level INSECURE_HOSTS allowlist in
+                # apps/scraper/http.py rather than blanket-disabling
+                # per-request. Callers that get a pnt.gob.mx-style cert
+                # issue should add the host to INSECURE_HOSTS, not
+                # sprinkle verify=False throughout the code.
+                response = self.session.get(url, timeout=120)
                 response.raise_for_status()
                 return {
                     "url": url,


### PR DESCRIPTION
Audit 2026-04-23 finding H7. Two scrapers sidestepped the centralized
INSECURE_HOSTS allowlist in apps/scraper/http.py and manually disabled
TLS verification for every request:

  - apps/scraper/federal/nom_scraper.py:273  session.verify = False
  - apps/scraper/municipal/pnt_scraper.py:604 get(..., verify=False)

Either misroute (proxy, redirect, env-driven base URL) would silently
send traffic to non-gov hosts with verify off, opening MITM on
compliance evidence that ultimately feeds Karafiel.

Changes:
- nom_scraper._setup_session wraps `session.request` to decide
  `verify=` per-URL against INSECURE_HOSTS (hostnames outside the
  allowlist now get proper verification).
- pnt_scraper drops the per-request `verify=False` override and
  trusts the session-level allowlist.
- Added `consultapublica.plataformadetransparencia.org.mx` to
  INSECURE_HOSTS — it's the real host pnt_scraper calls and its
  certificate chain has been chronically broken.



## Test plan
- [ ] Local smoke — reproduce the audit scenario and confirm it's blocked.
- [ ] CI green on the branch.
- [ ] Review the audit file-line anchors in `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

Full audit: `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
