### PR TITLE
fix(dockerfile): run mcp-server image as non-root UID 10001 [AUDIT I.1]

### DIFF
--- a/packages/mcp-server/Dockerfile
+++ b/packages/mcp-server/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.12-slim
 
+# Audit 2026-04-23 (cross-cutting I.1): create an unprivileged runtime user
+# so Kyverno pod-security policies don't need an exception and any escape
+# from the MCP server process can't write outside /app.
+RUN groupadd -r mcp --gid 10001 && useradd -r -g mcp --uid 10001 -m -d /home/mcp mcp
+
 WORKDIR /app
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -8,6 +13,9 @@ COPY pyproject.toml .
 RUN uv sync --no-dev
 
 COPY . .
+RUN chown -R mcp:mcp /app
+
+USER mcp
 
 EXPOSE 8000
 


### PR DESCRIPTION
Audit 2026-04-23 cross-cutting I.1. `packages/mcp-server/Dockerfile`
ran as root on `python:3.12-slim`. Kyverno's restricted pod-security
policy is scheduled to fail-close on root containers; getting ahead
of that now keeps the deploy green.

Creates a dedicated UID/GID 10001 `mcp` user, chowns `/app`, and sets
`USER mcp` before CMD. The MCP server is a simple FastAPI + stdio
transport — no special permissions needed.

## Test plan
- [ ] CI green on the branch.
- [ ] Review the audit file-line anchors in `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

Full audit: `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
