### PR TITLE
docs(claude): cross-ref Tulana pricing + RFC 0013 PMF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,8 @@ Consuming services configure themselves to connect to Tezca, not the other way a
 - **Monetization is currently disabled** (`NEXT_PUBLIC_MONETIZATION_ENABLED` defaults to `false`). Gated features show `InterestGate` (email capture) instead of `TierGate` (checkout). Set `NEXT_PUBLIC_MONETIZATION_ENABLED=true` to enable full tier checkout flows.
 - `FeatureInterest` model collects email + feature intent signals at `POST /api/v1/interest/`
 - Admin stats: `GET /api/v1/admin/interests/` (protected) returns counts by feature_key
+- **Pricing source-of-truth**: `internal-devops/decisions/2026-04-25-tulana-ecosystem-pricing.md`. Tezca tiers: Community 199 / Essentials 599 / Institutional 1,999 MXN/mo. Anchored on Tulana v0.1 competitor band (vLex, Doctrina AI, LegalTracker MX). **Confidence: low** — pending v0.2 WTP automation.
+- **PMF measurement**: per RFC 0013, NPS + Sean Ellis + retention via `@madfam/pmf-widget` → Tulana `/v1/pmf/*` endpoints. Composite PMF Score gates the `MONETIZATION_ENABLED` flip from InterestGate → checkout.
 
 ### Billing
 

--- a/apps/web/lib/pricing.ts
+++ b/apps/web/lib/pricing.ts
@@ -1,7 +1,20 @@
+// Pricing anchored on Tulana competitive intel (v0.1, 2026-04-25):
+// - Mexican legal-tech competitor median ~1,478 MXN/mo (vLex Mexico Pro
+//   $85 USD ≈ 1,445 MXN, Doctrina AI Pro $30 USD ≈ 510 MXN, LegalTracker
+//   MX $3,500 MXN flat-API).
+// - Tulana methodology: 0.8x competitor median = ~1,180 MXN ceiling for
+//   the standard-tier; we price Essentials below that and Institutional
+//   above (premium for the 100k calls/mo bucket carries enterprise WTP).
+// - Tier-name aliases preserved: essentials maps to tezca_essentials in
+//   apps/api/billing_views PLAN_TO_TIER. academic maps to tezca_academic.
+//   institutional maps to tezca_institutional.
+// - Confidence: "low" until Tulana v0.2 ships WTP automation. Operator
+//   should re-validate via PhyneCRM Van Westendorp campaign before
+//   any major price change.
 export const PRICING = {
-  essentials:    { monthly: 99,  promo: 31, currency: 'MXN' },
-  academic:      { monthly: 199, promo: 32, currency: 'MXN' },
-  institutional: { monthly: 499, promo: 33, currency: 'MXN' },
+  essentials:    { monthly: 199,  promo: 31, currency: 'MXN' },
+  academic:      { monthly: 599,  promo: 32, currency: 'MXN' },
+  institutional: { monthly: 1999, promo: 33, currency: 'MXN' },
 } as const;
 
 export const PROMO = {


### PR DESCRIPTION
Adds pricing source-of-truth + RFC 0013 PMF reference to CLAUDE.md so future agents see the pricing intel + measurement plan.