### PR TITLE
feat(web): scaffold PMF widget integration (gated, awaits NPM publish)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,21 @@ JANUA_SECRET_KEY=                   # jns_* from seed output (tezca-web)
 # SENTRY_ENVIRONMENT=production
 # SENTRY_TRACES_SAMPLE_RATE=0.1
 
+# ── PMF Widget (RFC 0013) ─────────────────────────────────────────────
+# Per RFC 0013, Tezca embeds @madfam/pmf-widget which posts NPS / Sean
+# Ellis / smile signals to Tulana's /v1/pmf/* endpoints. Composite PMF
+# Score from Tulana gates the MONETIZATION_ENABLED flip.
+#
+# Default: disabled. Flip to "true" only after:
+#   1. @madfam/pmf-widget@^0.1.0 is published to the MADFAM npm registry
+#      (currently blocked on NPM_MADFAM_TOKEN rotation, operator-only)
+#   2. `npm install @madfam/pmf-widget` succeeds in apps/web
+#   3. The local stub at apps/web/types/madfam-pmf-widget.d.ts is removed
+NEXT_PUBLIC_PMF_WIDGET_ENABLED=false
+# Tulana ingest endpoint base URL. Override in dev/staging if pointing
+# at a non-prod Tulana instance.
+NEXT_PUBLIC_TULANA_API_URL=https://api.tulana.madfam.io
+
 # ── Logging ───────────────────────────────────────────────────────────
 LOG_LEVEL=INFO
 DJANGO_LOG_LEVEL=INFO

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -70,6 +70,7 @@ import { Navbar } from "@/components/Navbar";
 import { ReadingProgressBar } from "@/components/ReadingProgressBar";
 import { BackToTop } from "@/components/BackToTop";
 import { PostHogProvider } from "@/components/PostHogProvider";
+import { PmfWidgetMount } from "@/components/pmf/PmfWidgetMount";
 import { Toaster } from "sonner";
 
 const januaConfig = {
@@ -114,6 +115,7 @@ export default function RootLayout({
                           <ComparisonFloatingBar />
                           <BackToTop />
                           <Toaster theme="system" position="top-right" richColors />
+                          <PmfWidgetMount />
                         </PostHogProvider>
                       </Suspense>
                     </ComparisonProvider>

--- a/apps/web/components/pmf/PmfWidgetMount.tsx
+++ b/apps/web/components/pmf/PmfWidgetMount.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * PmfWidgetMount — scaffolded integration for `@madfam/pmf-widget`.
+ *
+ * SCAFFOLD STATUS (read before "fixing" the dynamic import):
+ *
+ * `@madfam/pmf-widget@0.1.0` is built but NOT YET PUBLISHED to the
+ * MADFAM npm registry. Publish is blocked on `NPM_MADFAM_TOKEN`
+ * rotation (operator-only — see project_session_wrapup_2026-04-25.md
+ * task #38). The package is declared in apps/web/package.json so
+ * lockfile resolution lands the moment the publish unblocks, but
+ * `npm ci` in CI today resolves it as a missing optional-ish dep.
+ *
+ * To keep CI green BEFORE the publish:
+ *   1. The import is dynamic (runtime), not static — webpack/turbopack
+ *      do not resolve it at build time, so a missing module does not
+ *      fail the build.
+ *   2. The component is gated on `NEXT_PUBLIC_PMF_WIDGET_ENABLED`. Until
+ *      an operator flips the flag, the dynamic import never fires and
+ *      no runtime resolution is attempted.
+ *   3. A local type stub at `apps/web/types/madfam-pmf-widget.d.ts`
+ *      satisfies `tsc --noEmit` so typecheck passes without the package
+ *      installed. Delete the stub after the real package is installed
+ *      so the published types take over.
+ *
+ * Activation checklist (post-publish):
+ *   - Operator runs `npm install @madfam/pmf-widget@^0.1.0` in apps/web
+ *   - Set `NEXT_PUBLIC_PMF_WIDGET_ENABLED=true` in the deployed env
+ *   - Set `NEXT_PUBLIC_TULANA_API_URL` if not the default
+ *   - Delete `apps/web/types/madfam-pmf-widget.d.ts`
+ *
+ * See RFC 0013 (internal-devops/rfcs/0013-pmf-via-coforma-and-tulana.md)
+ * for the full PMF measurement architecture.
+ */
+
+import { useEffect, useState, type ComponentType } from 'react';
+import { useAuth } from '@/components/providers/AuthContext';
+
+const FLAG_ENABLED = process.env.NEXT_PUBLIC_PMF_WIDGET_ENABLED === 'true';
+const TULANA_API_URL =
+  process.env.NEXT_PUBLIC_TULANA_API_URL || 'https://api.tulana.madfam.io';
+
+// Minimal structural type matching @madfam/pmf-widget's PMFWidgetProps.
+// Kept narrow so we only depend on the props we actually pass; the real
+// types take over once the package is installed.
+interface PmfWidgetComponentProps {
+  product: string;
+  user: { id: string; email?: string; name?: string; plan?: string };
+  apiUrl: string;
+  triggers: {
+    nps?: { afterSession?: number; dismissCooldownDays?: number };
+    ellis?: { afterSession?: number; dismissCooldownDays?: number };
+    smile?: { afterAction?: { type: string; count: number } };
+  };
+  productLabel?: string;
+  disabled?: boolean;
+}
+
+type PmfWidgetModule = {
+  PMFWidget: ComponentType<PmfWidgetComponentProps>;
+};
+
+export function PmfWidgetMount() {
+  const auth = useAuth();
+  const [Widget, setWidget] = useState<ComponentType<PmfWidgetComponentProps> | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  useEffect(() => {
+    if (!FLAG_ENABLED) return;
+    if (!auth.isAuthenticated || !auth.userId) return;
+
+    let cancelled = false;
+    // Dynamic import keeps the build green when the package is not yet
+    // installed. Webpack/Turbopack treat the string as a runtime value,
+    // so it is not resolved at compile time.
+    const modulePath = '@madfam/pmf-widget';
+    import(/* webpackIgnore: true */ /* @vite-ignore */ modulePath)
+      .then((mod: PmfWidgetModule) => {
+        if (cancelled) return;
+        setWidget(() => mod.PMFWidget);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Package not installed yet (pre-publish) or transient runtime
+        // resolve failure. Fail closed — never break the page on a
+        // telemetry widget.
+        setLoadFailed(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.isAuthenticated, auth.userId]);
+
+  if (!FLAG_ENABLED) return null;
+  if (loadFailed) return null;
+  if (!Widget) return null;
+  if (!auth.isAuthenticated || !auth.userId) return null;
+
+  return (
+    <Widget
+      product="tezca"
+      user={{
+        id: auth.userId,
+        email: auth.email ?? undefined,
+        name: auth.name ?? undefined,
+        plan: auth.tier,
+      }}
+      apiUrl={TULANA_API_URL}
+      productLabel="Tezca"
+      triggers={{
+        nps: { afterSession: 5, dismissCooldownDays: 30 },
+        ellis: { afterSession: 3, dismissCooldownDays: 45 },
+        smile: { afterAction: { type: 'law_viewed', count: 3 } },
+      }}
+    />
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@janua/nextjs": "^0.1.5",
     "@janua/ui": "^0.1.1",
+    "@madfam/pmf-widget": "^0.1.0",
     "@radix-ui/react-slot": "^1.2.3",
     "@react-sigma/core": "^5.0.6",
     "@react-sigma/layout-forceatlas2": "^5.0.6",

--- a/apps/web/types/madfam-pmf-widget.d.ts
+++ b/apps/web/types/madfam-pmf-widget.d.ts
@@ -1,0 +1,50 @@
+/**
+ * TEMPORARY type stub for `@madfam/pmf-widget`.
+ *
+ * Why this exists:
+ *   `@madfam/pmf-widget@0.1.0` is built but not yet published to the
+ *   MADFAM npm registry (publish blocked on NPM_MADFAM_TOKEN rotation,
+ *   operator-only). Without the package installed, `tsc --noEmit`
+ *   cannot resolve the module specifier in PmfWidgetMount.tsx's
+ *   dynamic import, breaking typecheck in CI.
+ *
+ *   This stub gives the TypeScript compiler a minimal module shape so
+ *   it can satisfy the `import()` call signature. The runtime gate in
+ *   PmfWidgetMount.tsx (NEXT_PUBLIC_PMF_WIDGET_ENABLED) prevents the
+ *   import from ever firing in production until the operator opts in.
+ *
+ * DELETE THIS FILE after `npm install @madfam/pmf-widget@^0.1.0`
+ * succeeds — the published package ships its own .d.ts that supersedes
+ * this stub.
+ *
+ * See: components/pmf/PmfWidgetMount.tsx and RFC 0013.
+ */
+declare module '@madfam/pmf-widget' {
+  import type { ComponentType } from 'react';
+
+  export interface PMFWidgetProps {
+    product: string;
+    user: {
+      id: string;
+      email?: string;
+      name?: string;
+      plan?: string;
+      createdAt?: string;
+      locale?: string;
+    };
+    apiUrl: string;
+    triggers: Record<string, unknown>;
+    lang?: 'en' | 'es';
+    productLabel?: string;
+    context?: Record<string, string | number | boolean | null>;
+    theme?: 'light' | 'dark' | 'auto';
+    disabled?: boolean;
+    onSubmit?: (event: unknown) => void;
+    onDismiss?: (mode: string) => void;
+  }
+
+  export const PMFWidget: ComponentType<PMFWidgetProps>;
+  export function recordAction(type: string): void;
+  export function getSessionCount(): number;
+  export function getActionCount(type: string): number;
+}


### PR DESCRIPTION
## Summary

Scaffolds `@madfam/pmf-widget` mount in `apps/web` per **RFC 0013** (`internal-devops/rfcs/0013-pmf-via-coforma-and-tulana.md`). The widget collects NPS / Sean Ellis / smile signals and POSTs them to Tulana's `/v1/pmf/*` endpoints; the composite PMF Score gates the eventual `MONETIZATION_ENABLED` flip from InterestGate to checkout (per Tezca CLAUDE.md > Monetization).

## Why scaffold-vs-live

`@madfam/pmf-widget@0.1.0` is built and ready, but **not yet published** to the MADFAM npm registry — publish is blocked on `NPM_MADFAM_TOKEN` rotation, an operator-only task. Rather than wait, this PR ships a scaffold that can merge **before** the publish unblocks:

- **Dynamic import** in `PmfWidgetMount.tsx` — webpack/Turbopack treat the specifier as a runtime value and do not resolve it at compile time, so a missing `node_modules` entry does not break the build.
- **Feature flag** `NEXT_PUBLIC_PMF_WIDGET_ENABLED` defaults to `false`, so the dynamic import never even fires until an operator opts in. Fail-closed on import error.
- **Local type stub** at `apps/web/types/madfam-pmf-widget.d.ts` satisfies `tsc --noEmit` so CI typecheck passes. Delete this stub after `npm install` succeeds so the published `.d.ts` takes over.

Verified locally: typecheck error count is unchanged (62 -> 62, all pre-existing in `__tests__/`), lint reports 0 errors.

## Files touched

- `apps/web/package.json` — declare `@madfam/pmf-widget@^0.1.0`
- `apps/web/components/pmf/PmfWidgetMount.tsx` — flag-gated client mount, dynamic import, sources user identity from `AuthContext` (Janua sub + tier)
- `apps/web/types/madfam-pmf-widget.d.ts` — temporary type stub (delete post-publish)
- `apps/web/app/layout.tsx` — mount inside `PostHogProvider` (inherits Suspense + Auth context)
- `.env.example` — document the two new env vars with operator activation notes

## Operator activation (post NPM publish)

1. Rotate `NPM_MADFAM_TOKEN` (operator-only blocker)
2. `cd apps/web && npm install @madfam/pmf-widget@^0.1.0`
3. **Delete** `apps/web/types/madfam-pmf-widget.d.ts` — published types take over
4. Set `NEXT_PUBLIC_PMF_WIDGET_ENABLED=true` in the deployed env (Enclii)
5. Optionally override `NEXT_PUBLIC_TULANA_API_URL` (defaults to `https://api.tulana.madfam.io`)

## Mergeability

**This PR can and should merge before `@madfam/pmf-widget` publishes.** That is the entire point of the scaffold pattern — it removes a sequencing dependency between the widget package release and the Tezca integration so we are not gated on the operator-only NPM token rotation.

## Test plan

- [x] `npm run lint:web` — 0 errors (warnings unchanged from main)
- [x] `npx tsc --noEmit` in `apps/web` — error count unchanged from main (62 -> 62, none in PMF files)
- [ ] Post-publish: operator runs activation checklist above, confirms widget renders for authenticated users and submissions land in Tulana
- [ ] Post-publish: delete the `.d.ts` stub and re-run typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)