### PR TITLE
fix(cors-apikey): stop echoing wildcard Origin on missing-Origin preflight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -505,3 +505,12 @@ type Lang = 'es' | 'en' | 'nah';
 - R2 storage tests use `pytest.mark.skipif(not _has_boto3)` -- they skip in CI where boto3 is not installed
 - WeasyPrint and other optional deps are similarly skipped in CI
 - Docker Compose services have resource limits (cpu/memory) to prevent runaway containers
+
+## Known Issues — Audit 2026-04-23
+
+See `/Users/aldoruizluna/labspace/claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md` for the full ecosystem audit.
+
+- ~~**🟠 H2: CORS echoes `*` when `Origin` header missing on API-key preflight**~~ — Fixed 2026-04-23: missing Origin now 403s, allowed Origins echo back with `Vary: Origin`.
+- **🟠 H7: TLS verification disabled on government scrapers** — `apps/scraper/http.py:79`, `federal/nom_scraper.py:273`, `municipal/pnt_scraper.py:604`. MITM risk — attacker can forge compliance evidence flowing into Karafiel. Pin CA bundles; if gov sites use old certs, narrow `verify=False` to specific hostnames with cert-fingerprint pinning.
+- **🟡 M3: `DEBUG=True` in `.env`** — `.env:3`. If mounted into prod workload, Django serves debug page on 500. Never commit `.env`; prod should use `.env.production` with `DEBUG=False`.
+- **🟡 H13: `.env` committed** — git rm, rotate secrets.

--- a/apps/api/middleware/cors_apikey.py
+++ b/apps/api/middleware/cors_apikey.py
@@ -47,7 +47,16 @@ class APIKeyCORSMiddleware:
         return response
 
     def process_view(self, request, callback, callback_args, callback_kwargs):
-        """Handle preflight OPTIONS requests for API key consumers."""
+        """Handle preflight OPTIONS requests for API key consumers.
+
+        Audit 2026-04-23 H2: an earlier implementation fell back to
+        ``origin = request.META.get("HTTP_ORIGIN", "*")`` — so an OPTIONS
+        request with no ``Origin`` header got ``Access-Control-Allow-Origin: *``
+        and could be used by any page to probe the API-key surface. Browsers
+        always send Origin on preflight; a missing Origin here is either a
+        non-browser caller (shouldn't need CORS at all) or a misbehaving
+        client (also doesn't deserve a permissive response).
+        """
         if request.method != "OPTIONS":
             return None
         if not request.path.startswith("/api/"):
@@ -61,7 +70,12 @@ class APIKeyCORSMiddleware:
 
         from django.http import HttpResponse
 
-        origin = request.META.get("HTTP_ORIGIN", "*")
+        origin = request.META.get("HTTP_ORIGIN")
+        if not origin:
+            # No Origin header → not a real browser preflight. Refuse rather
+            # than echoing a wildcard.
+            return HttpResponse(status=403)
+
         response = HttpResponse()
         response["Access-Control-Allow-Origin"] = origin
         response["Access-Control-Allow-Methods"] = "GET, POST, PATCH, DELETE, OPTIONS"
@@ -69,5 +83,6 @@ class APIKeyCORSMiddleware:
             "X-API-Key, Content-Type, Accept, Authorization"
         )
         response["Access-Control-Max-Age"] = "86400"
+        response["Vary"] = "Origin"
         response.status_code = 204
         return response


### PR DESCRIPTION
Stale-but-real branch from prior work, now pushed. Single commit: 5a12f1e fix(cors-apikey): stop echoing wildcard Origin on missing-Origin preflight