### PR TITLE
feat(enclii): declare status entries via enclii.yaml

### DIFF
--- a/enclii.yaml
+++ b/enclii.yaml
@@ -7,6 +7,25 @@ metadata:
   name: tezca-api
   project: tezca
 spec:
+  status:
+    enabled: true
+    entries:
+      - name: Tezca Web
+        url: https://tezca.mx
+        group: Tezca
+        family: MADFAM Platform
+        description: Legal intelligence platform
+      - name: Tezca API
+        url: https://api.tezca.mx/health
+        href: https://api.tezca.mx
+        group: Tezca
+        family: MADFAM Platform
+        description: Legal data API
+      - name: Tezca Admin
+        url: https://admin.tezca.mx
+        group: Tezca
+        family: MADFAM Platform
+        description: Legal ops console
   runtime:
     port: 8000
   domains:


### PR DESCRIPTION
## Summary

Phase 2 of the zero-touch onboarding compliance arc. Declares this repo's `status.madfam.io` entries via the new `enclii.yaml` `status:` block introduced by [enclii#162](https://github.com/madfam-org/enclii/pull/162)'s regenerate handler.

The platform regenerate handler (`POST /v1/admin/status/regenerate`) projects every ecosystem repo's `enclii.yaml` `status.entries[]` into the platform's `apps/status/k8s/madfam/configmap.yaml`. With this PR, that projection is non-trivial for this repo — its entries flow from here to the configmap on next regenerate, instead of being authored in the configmap directly.

This replaces the manual configmap edit pattern that landed in [enclii#160](https://github.com/madfam-org/enclii/pull/160) (zero-touch policy violation per [internal-devops/rfcs/0014](https://github.com/madfam-org/internal-devops/blob/main/rfcs/0014-zero-touch-onboarding-policy.md)).

Source-of-truth lines for the entries copied here live at [`apps/status/k8s/madfam/configmap.yaml`](https://github.com/madfam-org/enclii/blob/main/apps/status/k8s/madfam/configmap.yaml) in the enclii repo.

## Test plan

- [ ] CI passes (yaml syntax + repo's existing checks)
- [ ] After merge, run `POST /v1/admin/status/regenerate` on the platform; configmap entries for this group remain unchanged (regenerate is idempotent against the existing configmap content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)