### PR TITLE
security(admin): sanitize DOF error_summary before API exposure

### DIFF
--- a/apps/api/admin_views.py
+++ b/apps/api/admin_views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 
 from django.conf import settings as django_settings
 from django.db import connection
@@ -29,6 +30,33 @@ from .schema import (
 from .tasks import PIPELINE_STATUS_FILE
 
 logger = logging.getLogger(__name__)
+
+
+# `AcquisitionLog.error_summary` can contain raw exception text from the
+# scraper pipeline (file paths, stack frames, occasionally credentials echoed
+# back from a misconfigured request). The admin DOF endpoint exposes it to
+# operators — never to end users — but even admin payloads should not carry
+# stack traces, both as defense-in-depth and to avoid surprising consumers
+# of the audit log. This helper keeps the human-readable first line of the
+# summary and drops any traceback markers. CodeQL alert: py/stack-trace-exposure.
+_TRACEBACK_MARKER = re.compile(r"(traceback|file \"|line \d+, in )", re.IGNORECASE)
+
+
+def _safe_error_summary(raw: str | None) -> str:
+    """Return a sanitized one-line summary suitable for API exposure.
+
+    - ``None`` or empty → ``"No changes detected"`` (preserves prior behavior).
+    - Single-line summaries (no traceback markers) pass through unchanged,
+      truncated to 500 chars.
+    - Multi-line content with a traceback collapses to the first line plus a
+      generic ``"... (details redacted)"`` suffix.
+    """
+    if not raw:
+        return "No changes detected"
+    first_line = raw.split("\n", 1)[0].strip()
+    if _TRACEBACK_MARKER.search(raw):
+        return f"{first_line[:300]} ... (details redacted)"
+    return first_line[:500]
 
 
 @extend_schema(
@@ -409,7 +437,7 @@ def dof_summary(request):
                 latest_dof.parameters.get("date") if latest_dof.parameters else None
             ),
             "total_entries": latest_dof.found,
-            "law_changes_summary": latest_dof.error_summary or "No changes detected",
+            "law_changes_summary": _safe_error_summary(latest_dof.error_summary),
             "checked_at": (
                 latest_dof.started_at.isoformat() if latest_dof.started_at else None
             ),

--- a/tests/api/test_admin_views.py
+++ b/tests/api/test_admin_views.py
@@ -543,3 +543,51 @@ class TestTaskHealthEndpoint:
         assert job["found"] == 5
         assert job["downloaded"] == 3
         assert job["failed"] == 2
+
+
+class TestSafeErrorSummary:
+    """Coverage for the stack-trace sanitizer fronting `dof_summary`.
+
+    See CodeQL alert py/stack-trace-exposure on `admin/dof/`. The endpoint is
+    admin-only but admin payloads should still not carry tracebacks (avoids
+    accidental leak of file paths or credentials echoed in exceptions).
+    """
+
+    def test_none_returns_default(self):
+        from apps.api.admin_views import _safe_error_summary
+
+        assert _safe_error_summary(None) == "No changes detected"
+
+    def test_empty_string_returns_default(self):
+        from apps.api.admin_views import _safe_error_summary
+
+        assert _safe_error_summary("") == "No changes detected"
+
+    def test_single_line_passes_through(self):
+        from apps.api.admin_views import _safe_error_summary
+
+        assert _safe_error_summary("3 law changes detected") == "3 law changes detected"
+
+    def test_traceback_redacts_after_first_line(self):
+        from apps.api.admin_views import _safe_error_summary
+
+        raw = (
+            "DOF download failed for 2026-04-26\n"
+            "Traceback (most recent call last):\n"
+            '  File "/app/scraper/dof.py", line 42, in fetch\n'
+            "    response.raise_for_status()\n"
+            "ConnectionError: api-key=secret123 leaked into stack"
+        )
+        result = _safe_error_summary(raw)
+        assert result.startswith("DOF download failed for 2026-04-26")
+        assert "(details redacted)" in result
+        assert "secret123" not in result
+        assert "/app/scraper/dof.py" not in result
+
+    def test_long_single_line_truncates(self):
+        from apps.api.admin_views import _safe_error_summary
+
+        raw = "x" * 1000
+        result = _safe_error_summary(raw)
+        assert len(result) == 500
+

--- a/tests/api/test_admin_views.py
+++ b/tests/api/test_admin_views.py
@@ -590,4 +590,3 @@ class TestSafeErrorSummary:
         raw = "x" * 1000
         result = _safe_error_summary(raw)
         assert len(result) == 500
-


### PR DESCRIPTION
## Summary
Resolves CodeQL alert [py/stack-trace-exposure (#21)](https://github.com/madfam-org/tezca/security/code-scanning/21) on the admin \`/dof/\` endpoint.

\`AcquisitionLog.error_summary\` is populated by the scraper pipeline with raw exception text (truncated to 2000 chars at write time — see \`apps/scraper/scheduling/tasks.py:44\`). Even though \`_protected(dof_summary)\` is admin-only, raw tracebacks should not flow into API payloads — they can leak file paths, internal class names, and occasionally credentials echoed back from a misconfigured request.

The new \`_safe_error_summary(raw)\` helper:
- Returns "No changes detected" for None/empty (preserves prior behavior)
- Single-line summaries pass through unchanged, truncated at 500 chars
- Multi-line content with traceback markers (\`"Traceback"\`, \`'File "'\`, \`"line N, in "\`) collapses to \`<first line> ... (details redacted)\`

## Test plan
- [x] 5 unit tests in \`tests/api/test_admin_views.py::TestSafeErrorSummary\` covering: None/empty default, single-line passthrough, traceback redaction (verifies a leaked api-key=secret123 does NOT survive), length truncation
- [x] Local: \`poetry run pytest tests/api/test_admin_views.py::TestSafeErrorSummary -v\` → 5/5 pass

## Sibling alerts dismissed separately
The three py/clear-text-logging alerts (#22/#23/#24) are CodeQL false positives — they flag a Redis stream topic name (\`STREAM_KEY = "madfam:billing-events"\`) and integer counters (\`result["processed"]\`, \`result["errors"]\`), neither of which are credentials. Being dismissed with \`false_positive\` rationale.

## Refs
- Ecosystem security remediation plan §Wave 0 (tezca)

🤖 Generated with [Claude Code](https://claude.com/claude-code)