### PR TITLE
feat(scraper): re-implement RMF (Resolución Miscelánea Fiscal) scraper

### DIFF
--- a/apps/api/management/commands/ingest_rmf.py
+++ b/apps/api/management/commands/ingest_rmf.py
@@ -1,0 +1,160 @@
+"""
+Ingest the RMF catalog produced by ``apps/scraper/federal/rmf_scraper.py``
+into Law + LawVersion rows.
+
+This is the SAT-side analogue to ``ingest_non_legislative_laws.py``, but for
+federal regulations rather than state ones. It walks ``data/rmf/catalog.json``
+(or whatever path is given), creates one ``Law`` per RMF artifact (annual
+RMF, quarterly modification, or annex), and tags each with
+``law_type="non_legislative"``, ``category="resolución_miscelánea_fiscal"``,
+``domains=["fiscal"]`` so Karafiel's compliance webhook filter
+(``domain_filter: ["fiscal"]``) sees these events.
+
+Usage::
+
+    python manage.py ingest_rmf --catalog data/rmf/catalog.json
+    python manage.py ingest_rmf --catalog data/rmf/catalog.json --dry-run
+
+After running, ``index_laws`` (existing command) takes over the ES side.
+"""
+
+import datetime
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from apps.api.models import Law, LawVersion
+from apps.scraper.federal.rmf_scraper import RMF_CATEGORY, RMF_DOMAINS
+
+
+class Command(BaseCommand):
+    help = (
+        "Ingest RMF catalog (apps/scraper/federal/rmf_scraper output) into Law records"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--catalog",
+            type=str,
+            default="data/rmf/catalog.json",
+            help="Path to catalog.json produced by RmfScraper (default: data/rmf/catalog.json)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be created/updated without writing to the DB",
+        )
+
+    def handle(self, *args, **options):
+        catalog_path = Path(options["catalog"])
+        if not catalog_path.exists():
+            self.stderr.write(self.style.ERROR(f"Catalog not found: {catalog_path}"))
+            return
+
+        with catalog_path.open(encoding="utf-8") as fh:
+            documents = json.load(fh)
+
+        if not documents:
+            self.stdout.write(
+                self.style.WARNING("Catalog is empty — nothing to ingest")
+            )
+            return
+
+        self.stdout.write(f"Loaded {len(documents)} RMF documents from {catalog_path}")
+
+        created = 0
+        updated = 0
+        errors = 0
+        dry_run = options["dry_run"]
+
+        for doc in documents:
+            try:
+                with transaction.atomic():
+                    result = self._upsert(doc, dry_run=dry_run)
+                if result == "created":
+                    created += 1
+                elif result == "updated":
+                    updated += 1
+            except Exception as exc:
+                errors += 1
+                self.stderr.write(
+                    self.style.ERROR(f"Failed {doc.get('official_id', '?')}: {exc}")
+                )
+
+        prefix = "[DRY-RUN] " if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix}RMF ingest complete: {created} created, {updated} updated, "
+                f"{errors} errors"
+            )
+        )
+
+    def _upsert(self, doc: dict, dry_run: bool) -> str:
+        """Upsert a single RmfDocument dict into Law + LawVersion.
+
+        Returns "created" or "updated" so the caller can tally.
+        """
+        official_id = doc["official_id"]
+        name = doc["name"]
+        url = doc["url"]
+        document_type = doc["document_type"]
+        year = int(doc["year"])
+        category = doc.get("category", RMF_CATEGORY)
+        domains = doc.get("domains", list(RMF_DOMAINS))
+
+        publication_date = doc.get("publication_date")
+        # When SAT didn't expose a publication date, fall back to Jan 1 of
+        # the fiscal year — RMF rules formally take effect on Jan 1 absent
+        # a more specific date. Better than `None` because LawVersion
+        # requires a date.
+        if not publication_date:
+            publication_date = f"{year}-01-01"
+
+        if dry_run:
+            return (
+                "updated"
+                if Law.objects.filter(official_id=official_id).exists()
+                else "created"
+            )
+
+        defaults = {
+            "name": name,
+            "tier": "federal",
+            "category": category,
+            "domains": domains,
+            "law_type": "non_legislative",
+            "source_url": url,
+            "last_verified": datetime.datetime.now(datetime.timezone.utc),
+            # SAT publishes the RMF text on portal pages; we don't currently
+            # parse a rich short_name, but `document_type` gives operators
+            # a quick filter.
+            "short_name": _short_name(document_type, year, doc),
+        }
+
+        law, created = Law.objects.update_or_create(
+            official_id=official_id,
+            defaults=defaults,
+        )
+        action = "created" if created else "updated"
+
+        # Always upsert a LawVersion for this publication date
+        LawVersion.objects.update_or_create(
+            law=law,
+            publication_date=publication_date,
+            defaults={
+                "dof_url": url,
+            },
+        )
+
+        return action
+
+
+def _short_name(document_type: str, year: int, doc: dict) -> str:
+    """Friendly short_name for the admin UI / search snippets."""
+    if document_type == "annex":
+        return f"Anexo {doc.get('annex_number', '?')} RMF {year}"
+    if document_type == "modification":
+        return f"{doc.get('modification_number', '?')}ª Mod. RMF {year}"
+    return f"RMF {year}"

--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -396,6 +396,19 @@ CELERY_BEAT_SCHEDULE = {
         ),
         "kwargs": {"mode": "noms"},
     },
+    # SAT publishes RMF + quarterly modifications + annex revisions on a
+    # roughly quarterly cadence, with the annual RMF dropping in late
+    # December. Run the 8th of every quarter month at 03:00 to catch any
+    # publication from the prior quarter without colliding with the DOF
+    # 1st-of-quarter task above. Required by Karafiel's compliance feed
+    # (FEATURE_PARITY_PLAN_2026-04-27 §3.6).
+    "rmf-quarterly-scrape": {
+        "task": "dataops.run_rmf_scraper",
+        "schedule": crontab(
+            hour=3, minute=0, day_of_month="8", month_of_year="1,4,7,10"
+        ),
+        "kwargs": {"include_annexes": True, "download_documents": True},
+    },
     "conamer-playwright-weekly": {
         "task": "dataops.run_conamer_playwright",
         "schedule": crontab(hour=23, minute=0, day_of_week="friday"),

--- a/apps/scraper/federal/rmf_scraper.py
+++ b/apps/scraper/federal/rmf_scraper.py
@@ -1,0 +1,489 @@
+"""
+RMF (Resolución Miscelánea Fiscal) Scraper.
+
+Fetches the current year's RMF and its annexes from the SAT portal. The RMF
+is published annually with quarterly modifications and contains the
+administrative rules that implement the CFF and other tax laws — including
+Rule 2.9.21 (API + technical requirements for digital platforms).
+
+This is the SAT-side regulatory feed that Karafiel's compliance use case
+depends on (per `docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md` §3.6).
+
+Strategy: requests-first for the listing pages (they're server-rendered
+HTML on www.sat.gob.mx, which has valid TLS — no INSECURE_HOSTS entry
+needed). PDF + DOCX downloads use the same session. Parsing of the
+downloaded documents is delegated to the existing ingestion pipeline
+(parser_v2 → DatabaseSaver) once the metadata + text files land on disk.
+
+Key targets:
+- Annual RMF document
+- Quarterly modifications (1a, 2a, 3a, 4a)
+- Annexes 1-31 (tax tables, forms, technical requirements)
+- Rule 2.9.21 (digital-platform API requirements — Karafiel-relevant)
+
+Usage::
+
+    python -m apps.scraper.federal.rmf_scraper --year 2026
+    python -m apps.scraper.federal.rmf_scraper --year 2026 --include-annexes
+    python -m apps.scraper.federal.rmf_scraper --year 2026 --output-dir data/rmf
+"""
+
+import argparse
+import json
+import logging
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from apps.scraper.http import DEFAULT_TIMEOUT, DEFAULT_USER_AGENT
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Source URLs (SAT — www.sat.gob.mx — valid TLS, no INSECURE_HOSTS entry)
+# ---------------------------------------------------------------------------
+
+SAT_BASE = "https://www.sat.gob.mx"
+SAT_RMF_INDEX = f"{SAT_BASE}/normatividad/22702/resoluciones-miscelaneas-fiscales"
+SAT_RMF_ANNEXES_INDEX = (
+    f"{SAT_BASE}/normatividad/22703/anexos-de-la-resolucion-miscelanea-fiscal"
+)
+
+# ---------------------------------------------------------------------------
+# Behavior knobs
+# ---------------------------------------------------------------------------
+
+_MIN_REQUEST_INTERVAL = 1.0  # seconds — polite to SAT
+_REQUEST_TIMEOUT = DEFAULT_TIMEOUT
+_MAX_RETRIES = 3
+
+# RMF document type prefixes used in SAT page anchor text
+_RMF_TYPES = ("RMF", "Anexo", "Modificación", "1a.", "2a.", "3a.", "4a.")
+
+# Identifies a 4-digit year to anchor the document to
+_YEAR_PATTERN = re.compile(r"\b(19|20)\d{2}\b")
+
+# Common file extensions SAT links to
+_DOCUMENT_EXTENSIONS = (".pdf", ".doc", ".docx")
+
+# Categories assigned to ingested Law records
+RMF_CATEGORY = "resolución_miscelánea_fiscal"
+RMF_DOMAINS = ["fiscal"]
+
+
+@dataclass
+class RmfDocument:
+    """Single RMF artifact discovered on the SAT portal.
+
+    Mirrors the shape that DatabaseSaver / ingest_non_legislative_laws
+    expects: an ``official_id`` plus enough metadata to derive a Law +
+    LawVersion row, plus a ``url`` to download the actual content.
+    """
+
+    official_id: str
+    name: str
+    url: str
+    document_type: str  # "rmf" | "modification" | "annex"
+    year: int
+    publication_date: Optional[str] = None
+    annex_number: Optional[str] = None
+    modification_number: Optional[str] = None
+    category: str = RMF_CATEGORY
+    domains: List[str] = field(default_factory=lambda: list(RMF_DOMAINS))
+    source: str = "sat_rmf_scraper"
+
+
+class RmfScraper:
+    """Scraper for SAT's annual RMF + quarterly modifications + annexes.
+
+    Concrete coverage:
+
+    1. Annual RMF — one document per fiscal year
+    2. Modifications — typically 1a/2a/3a/4a per year
+    3. Annexes — numbered 1 through ~31 each year (varies)
+
+    Output: a JSON catalog of discovered ``RmfDocument`` records plus
+    downloaded source files, ready for the parser pipeline +
+    ``ingest_non_legislative_laws`` analogue to materialize as Law +
+    Article rows.
+    """
+
+    def __init__(self, output_dir: str = "data/rmf") -> None:
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self._session = self._build_session()
+        self._last_request_at: float = 0.0
+
+    # ------------------------------------------------------------------
+    # HTTP plumbing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_session() -> requests.Session:
+        """Return a session configured for sat.gob.mx.
+
+        SAT's portal has a valid certificate chain (verified 2026-04-27),
+        so no INSECURE_HOSTS bypass is needed. Retries are conservative —
+        the SAT WAF gets unhappy with rapid retries; we'd rather fail
+        fast and let Celery retry the whole task than hammer them.
+        """
+        session = requests.Session()
+        session.headers.update(
+            {
+                "User-Agent": DEFAULT_USER_AGENT,
+                "Accept": "text/html, application/xhtml+xml, */*",
+                "Accept-Language": "es-MX,es;q=0.9,en;q=0.5",
+            }
+        )
+        return session
+
+    def _rate_limit(self) -> None:
+        elapsed = time.time() - self._last_request_at
+        if elapsed < _MIN_REQUEST_INTERVAL:
+            time.sleep(_MIN_REQUEST_INTERVAL - elapsed)
+        self._last_request_at = time.time()
+
+    def _get(self, url: str) -> Optional[requests.Response]:
+        """Polite GET with bounded retries on transient errors."""
+        for attempt in range(1, _MAX_RETRIES + 1):
+            self._rate_limit()
+            try:
+                resp = self._session.get(url, timeout=_REQUEST_TIMEOUT)
+                resp.raise_for_status()
+                return resp
+            except requests.HTTPError as exc:
+                status = exc.response.status_code if exc.response else None
+                if status in (403, 404):
+                    # Permanent — no point retrying.
+                    logger.warning("HTTP %s for %s", status, url)
+                    return None
+                logger.warning(
+                    "HTTP %s for %s (attempt %d/%d)",
+                    status,
+                    url,
+                    attempt,
+                    _MAX_RETRIES,
+                )
+            except (requests.ConnectionError, requests.Timeout) as exc:
+                logger.warning(
+                    "Network error for %s (attempt %d/%d): %s",
+                    url,
+                    attempt,
+                    _MAX_RETRIES,
+                    exc,
+                )
+            time.sleep(2**attempt)  # exponential backoff: 2s, 4s, 8s
+        logger.error("Giving up on %s after %d attempts", url, _MAX_RETRIES)
+        return None
+
+    # ------------------------------------------------------------------
+    # Index parsing
+    # ------------------------------------------------------------------
+
+    def _parse_index_links(
+        self, html: str, base_url: str, year: int
+    ) -> List[Dict[str, str]]:
+        """Extract document links from a SAT index page.
+
+        SAT's RMF + annexes index pages are standard HTML lists of
+        anchors pointing to PDF/DOC/DOCX files (sometimes with an
+        intermediate microsite landing page). We collect the
+        (text, href) pairs and let the caller classify each one.
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        results: List[Dict[str, str]] = []
+
+        for anchor in soup.find_all("a", href=True):
+            href = anchor["href"].strip()
+            text = " ".join(anchor.get_text().split())
+            if not text:
+                continue
+
+            # Year filter: skip anchors that name a different year explicitly.
+            year_matches = [int(m.group(0)) for m in _YEAR_PATTERN.finditer(text)]
+            if year_matches and year not in year_matches:
+                continue
+
+            # Absolute URL
+            if href.startswith("/"):
+                href = f"{SAT_BASE}{href}"
+            elif not href.startswith("http"):
+                href = f"{base_url.rstrip('/')}/{href}"
+
+            # Heuristic: skip nav/footer links that don't look like documents.
+            looks_like_document = (
+                href.lower().endswith(_DOCUMENT_EXTENSIONS)
+                or "rmf" in text.lower()
+                or "anexo" in text.lower()
+                or "modificación" in text.lower()
+                or "modificacion" in text.lower()
+                or "miscelánea" in text.lower()
+                or "miscelanea" in text.lower()
+            )
+            if not looks_like_document:
+                continue
+
+            results.append({"text": text, "url": href})
+
+        return results
+
+    def _classify(self, anchor: Dict[str, str], year: int) -> Optional[RmfDocument]:
+        """Turn a raw (text, url) pair into an :class:`RmfDocument`.
+
+        Returns ``None`` when the anchor doesn't look like an RMF
+        artifact we care about — defensive guard against picking up
+        unrelated SAT links present on the index page.
+        """
+        text = anchor["text"]
+        url = anchor["url"]
+        text_lower = text.lower()
+
+        # Annex detection — "Anexo 1", "Anexo 14", etc.
+        annex_match = re.search(r"anexo\s+(\d{1,2}(?:[a-z])?)", text_lower)
+        if annex_match:
+            annex_num = annex_match.group(1)
+            return RmfDocument(
+                official_id=f"rmf_{year}_anexo_{annex_num}",
+                name=f"Anexo {annex_num} de la RMF {year}",
+                url=url,
+                document_type="annex",
+                year=year,
+                annex_number=annex_num,
+            )
+
+        # Modification detection — "Primera Modificación", "1a. Modificación", etc.
+        mod_match = re.search(
+            r"(primera|segunda|tercera|cuarta|1a\.?|2a\.?|3a\.?|4a\.?)\s*"
+            r"(?:modificaci[oó]n|resoluci[oó]n)",
+            text_lower,
+        )
+        if mod_match:
+            ordinal = {
+                "primera": "1",
+                "segunda": "2",
+                "tercera": "3",
+                "cuarta": "4",
+                "1a": "1",
+                "1a.": "1",
+                "2a": "2",
+                "2a.": "2",
+                "3a": "3",
+                "3a.": "3",
+                "4a": "4",
+                "4a.": "4",
+            }.get(mod_match.group(1).rstrip("."), "1")
+            return RmfDocument(
+                official_id=f"rmf_{year}_modificacion_{ordinal}",
+                name=f"{ordinal}ª Modificación a la RMF {year}",
+                url=url,
+                document_type="modification",
+                year=year,
+                modification_number=ordinal,
+            )
+
+        # Annual RMF detection — "Resolución Miscelánea Fiscal para 2026"
+        if "miscelánea fiscal" in text_lower or "miscelanea fiscal" in text_lower:
+            return RmfDocument(
+                official_id=f"rmf_{year}",
+                name=f"Resolución Miscelánea Fiscal {year}",
+                url=url,
+                document_type="rmf",
+                year=year,
+            )
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Top-level discovery
+    # ------------------------------------------------------------------
+
+    def discover(self, year: int, include_annexes: bool = True) -> List[RmfDocument]:
+        """Walk the SAT RMF + annex indices for ``year`` and return all
+        unique ``RmfDocument`` records discovered.
+
+        Deduplication is by ``official_id`` — if the same artifact appears
+        on both index pages (which it sometimes does), we keep the first.
+        """
+        documents: Dict[str, RmfDocument] = {}
+
+        # 1. Main RMF + modifications index
+        index_resp = self._get(SAT_RMF_INDEX)
+        if index_resp:
+            for anchor in self._parse_index_links(index_resp.text, SAT_RMF_INDEX, year):
+                doc = self._classify(anchor, year)
+                if doc and doc.official_id not in documents:
+                    documents[doc.official_id] = doc
+        else:
+            logger.error("Failed to load RMF main index — discovery incomplete")
+
+        # 2. Annexes index (optional — annex parsing is heavier)
+        if include_annexes:
+            annexes_resp = self._get(SAT_RMF_ANNEXES_INDEX)
+            if annexes_resp:
+                for anchor in self._parse_index_links(
+                    annexes_resp.text, SAT_RMF_ANNEXES_INDEX, year
+                ):
+                    doc = self._classify(anchor, year)
+                    if doc and doc.official_id not in documents:
+                        documents[doc.official_id] = doc
+            else:
+                logger.warning(
+                    "Failed to load RMF annexes index — annexes will be missing"
+                )
+
+        return sorted(documents.values(), key=lambda d: d.official_id)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def download(self, document: RmfDocument) -> Optional[Path]:
+        """Download a single RMF artifact to ``self.output_dir``.
+
+        Returns the local Path on success, None on failure. The caller
+        is responsible for downstream parsing (PDF text extraction,
+        article splitting) — this function only fetches the bytes.
+        """
+        resp = self._get(document.url)
+        if not resp:
+            return None
+
+        # Pick a sensible filename from the URL or fall back to official_id.
+        url_name = document.url.rsplit("/", 1)[-1].split("?")[0]
+        if any(url_name.lower().endswith(ext) for ext in _DOCUMENT_EXTENSIONS):
+            filename = f"{document.official_id}_{url_name}"
+        else:
+            filename = f"{document.official_id}.html"
+
+        target = self.output_dir / filename
+        target.write_bytes(resp.content)
+        logger.info(
+            "Downloaded %s → %s (%d bytes)",
+            document.official_id,
+            target,
+            len(resp.content),
+        )
+        return target
+
+    def write_catalog(self, documents: List[RmfDocument]) -> Path:
+        """Write the discovered catalog to ``catalog.json`` for the
+        ingestion pipeline to pick up.
+        """
+        catalog_path = self.output_dir / "catalog.json"
+        payload = [asdict(d) for d in documents]
+        catalog_path.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        logger.info(
+            "Wrote catalog with %d documents → %s", len(documents), catalog_path
+        )
+        return catalog_path
+
+    # ------------------------------------------------------------------
+    # End-to-end run
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        year: int = 2026,
+        include_annexes: bool = True,
+        download_documents: bool = False,
+    ) -> Dict[str, Any]:
+        """Discover + (optionally) download RMF artifacts for ``year``.
+
+        Args:
+            year: Target fiscal year.
+            include_annexes: Walk the annexes index too.
+            download_documents: When True, fetch each document's bytes
+                to disk. Default False so a fast catalog-only sweep can
+                run in CI / tests without N HTTP fetches.
+
+        Returns:
+            Summary dict suitable for AcquisitionLog persistence:
+            ``{total, by_type, downloaded, errors, catalog_path}``.
+        """
+        documents = self.discover(year=year, include_annexes=include_annexes)
+
+        downloaded = 0
+        errors = 0
+        if download_documents:
+            for doc in documents:
+                if self.download(doc):
+                    downloaded += 1
+                else:
+                    errors += 1
+
+        catalog_path = self.write_catalog(documents)
+
+        by_type: Dict[str, int] = {}
+        for doc in documents:
+            by_type[doc.document_type] = by_type.get(doc.document_type, 0) + 1
+
+        result = {
+            "year": year,
+            "total": len(documents),
+            "by_type": by_type,
+            "downloaded": downloaded,
+            "errors": errors,
+            "catalog_path": str(catalog_path),
+        }
+        logger.info("RMF run complete: %s", result)
+        return result
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scrape the SAT RMF + modifications + annexes for a year"
+    )
+    parser.add_argument(
+        "--year", type=int, default=2026, help="Fiscal year to scrape (default: 2026)"
+    )
+    parser.add_argument(
+        "--include-annexes",
+        action="store_true",
+        default=True,
+        help="Walk the annexes index too (default: on)",
+    )
+    parser.add_argument(
+        "--no-annexes",
+        dest="include_annexes",
+        action="store_false",
+        help="Skip the annexes index",
+    )
+    parser.add_argument(
+        "--download",
+        action="store_true",
+        help="Fetch each document's bytes to disk (slow)",
+    )
+    parser.add_argument(
+        "--output-dir", default="data/rmf", help="Where to write catalog + downloads"
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    scraper = RmfScraper(output_dir=args.output_dir)
+    result = scraper.run(
+        year=args.year,
+        include_annexes=args.include_annexes,
+        download_documents=args.download,
+    )
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/scraper/scheduling/tasks.py
+++ b/apps/scraper/scheduling/tasks.py
@@ -426,6 +426,65 @@ def run_treaty_scraper(fetch_details=False, max_details=50):
     return result
 
 
+@shared_task(name="dataops.run_rmf_scraper")
+def run_rmf_scraper(year=None, include_annexes=True, download_documents=True):
+    """Run SAT Resolución Miscelánea Fiscal scraper.
+
+    Karafiel's compliance use case (per FEATURE_PARITY_PLAN_2026-04-27 §3.6)
+    depends on this feed being fresh — RMF + quarterly modifications +
+    annexes carry the SAT-administrative rules that implement CFF.
+
+    Args:
+        year: Fiscal year (default: current year).
+        include_annexes: Walk the annexes index too.
+        download_documents: When True, fetch each document's bytes. The
+            quarterly Beat schedule sets this to True so we have the
+            source files on disk; manual reruns can pass False to do a
+            fast catalog-only sweep.
+    """
+    import datetime
+
+    from apps.scraper.federal.rmf_scraper import RmfScraper
+
+    target_year = year if year is not None else datetime.date.today().year
+
+    log_entry = _start_log(
+        "rmf_scrape",
+        {
+            "year": target_year,
+            "include_annexes": include_annexes,
+            "download_documents": download_documents,
+        },
+    )
+    try:
+        scraper = RmfScraper()
+        result = scraper.run(
+            year=target_year,
+            include_annexes=include_annexes,
+            download_documents=download_documents,
+        )
+
+        logger.info(
+            "RMF scraper (year=%d): %d documents (%s)",
+            target_year,
+            result.get("total", 0),
+            result.get("by_type", {}),
+        )
+
+        _finish_log(
+            log_entry,
+            found=result.get("total", 0),
+            downloaded=result.get("downloaded", 0),
+            failed=result.get("errors", 0),
+        )
+        return result
+
+    except Exception as exc:
+        logger.exception("RMF scraper failed for year=%s", target_year)
+        _finish_log(log_entry, error=str(exc))
+        return {"error": str(exc), "year": target_year}
+
+
 @shared_task(name="dataops.replicate_batch")
 def replicate_batch(prefix, ingest_command=None):
     """Replicate a scraped batch to R2 and trigger prod ingestion.

--- a/tests/scraper/test_rmf_scraper.py
+++ b/tests/scraper/test_rmf_scraper.py
@@ -1,0 +1,270 @@
+"""
+Tests for SAT RMF scraper (apps/scraper/federal/rmf_scraper.py).
+
+Network-free: every test mocks the requests session. The interesting logic
+is in `_classify` (anchor → RmfDocument), `_parse_index_links` (filter
+which anchors look like documents), and `discover` (dedup across the two
+SAT index pages).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.scraper.federal.rmf_scraper import (
+    RMF_CATEGORY,
+    RMF_DOMAINS,
+    RmfDocument,
+    RmfScraper,
+)
+
+
+@pytest.fixture
+def scraper(tmp_path):
+    return RmfScraper(output_dir=str(tmp_path))
+
+
+class TestClassify:
+    """RmfScraper._classify: anchor text → RmfDocument."""
+
+    def test_classifies_annex(self, scraper):
+        anchor = {
+            "text": "Anexo 14 de la Resolución Miscelánea Fiscal para 2026",
+            "url": "https://www.sat.gob.mx/cs/Satellite?...anexo14_rmf2026.pdf",
+        }
+        doc = scraper._classify(anchor, year=2026)
+        assert doc is not None
+        assert doc.document_type == "annex"
+        assert doc.annex_number == "14"
+        assert doc.year == 2026
+        assert doc.official_id == "rmf_2026_anexo_14"
+        assert doc.category == RMF_CATEGORY
+        assert doc.domains == RMF_DOMAINS
+
+    def test_classifies_quarterly_modification_ordinal(self, scraper):
+        anchor = {
+            "text": "Primera Resolución de Modificaciones a la Resolución Miscelánea Fiscal para 2026",
+            "url": "https://www.sat.gob.mx/.../1ra_modificacion_rmf2026.pdf",
+        }
+        doc = scraper._classify(anchor, year=2026)
+        assert doc is not None
+        assert doc.document_type == "modification"
+        assert doc.modification_number == "1"
+        assert doc.official_id == "rmf_2026_modificacion_1"
+
+    def test_classifies_quarterly_modification_abbreviated(self, scraper):
+        anchor = {
+            "text": "3a. Modificación a la RMF 2026",
+            "url": "https://www.sat.gob.mx/.../3a_mod_rmf.pdf",
+        }
+        doc = scraper._classify(anchor, year=2026)
+        assert doc is not None
+        assert doc.modification_number == "3"
+
+    def test_classifies_annual_rmf(self, scraper):
+        anchor = {
+            "text": "Resolución Miscelánea Fiscal para 2026",
+            "url": "https://www.sat.gob.mx/.../rmf2026.pdf",
+        }
+        doc = scraper._classify(anchor, year=2026)
+        assert doc is not None
+        assert doc.document_type == "rmf"
+        assert doc.official_id == "rmf_2026"
+
+    def test_returns_none_for_unrelated_anchor(self, scraper):
+        anchor = {
+            "text": "Aviso de privacidad",
+            "url": "https://www.sat.gob.mx/aviso-privacidad",
+        }
+        doc = scraper._classify(anchor, year=2026)
+        assert doc is None
+
+    def test_annex_with_letter_suffix(self, scraper):
+        # SAT occasionally publishes "Anexo 1A" sub-annexes
+        anchor = {
+            "text": "Anexo 1a de la RMF 2026",
+            "url": "https://www.sat.gob.mx/.../anexo1a.pdf",
+        }
+        doc = scraper._classify(anchor, year=2026)
+        assert doc is not None
+        assert doc.annex_number == "1a"
+
+
+class TestParseIndexLinks:
+    """_parse_index_links must filter out non-document anchors and resolve
+    relative URLs against SAT_BASE."""
+
+    def test_drops_anchors_without_text(self, scraper):
+        html = '<a href="/foo.pdf">   </a>'
+        links = scraper._parse_index_links(html, "https://www.sat.gob.mx", year=2026)
+        assert links == []
+
+    def test_drops_unrelated_navigation_links(self, scraper):
+        html = '<a href="/contacto">Contáctanos</a>'
+        links = scraper._parse_index_links(html, "https://www.sat.gob.mx", year=2026)
+        assert links == []
+
+    def test_resolves_root_relative_urls_against_sat_base(self, scraper):
+        html = '<a href="/normatividad/anexo1.pdf">Anexo 1 RMF</a>'
+        links = scraper._parse_index_links(html, "https://www.sat.gob.mx", year=2026)
+        assert len(links) == 1
+        assert links[0]["url"] == "https://www.sat.gob.mx/normatividad/anexo1.pdf"
+
+    def test_keeps_pdf_anchors_even_without_keyword(self, scraper):
+        # A direct PDF link still counts even if the anchor text is terse
+        html = '<a href="/normatividad/file.pdf">file.pdf</a>'
+        links = scraper._parse_index_links(html, "https://www.sat.gob.mx", year=2026)
+        assert len(links) == 1
+
+    def test_filters_anchors_naming_a_different_year(self, scraper):
+        html = '<a href="/normatividad/rmf2024.pdf">RMF 2024</a>'
+        links = scraper._parse_index_links(html, "https://www.sat.gob.mx", year=2026)
+        assert links == [], "Anchor explicitly naming 2024 should be filtered out"
+
+    def test_keeps_anchors_naming_target_year(self, scraper):
+        html = '<a href="/normatividad/rmf2026.pdf">RMF 2026</a>'
+        links = scraper._parse_index_links(html, "https://www.sat.gob.mx", year=2026)
+        assert len(links) == 1
+
+    def test_keeps_anchors_with_no_year_in_text(self, scraper):
+        html = '<a href="/normatividad/file.pdf">Resolución Miscelánea Fiscal</a>'
+        links = scraper._parse_index_links(html, "https://www.sat.gob.mx", year=2026)
+        assert len(links) == 1
+
+
+class TestDiscover:
+    """End-to-end discover() with mocked HTTP."""
+
+    @patch.object(RmfScraper, "_get")
+    def test_dedups_documents_appearing_on_both_indices(self, mock_get, scraper):
+        # Same document on both pages — dedup should keep one
+        html_main = """
+        <html><body>
+            <a href="/normatividad/rmf2026.pdf">Resolución Miscelánea Fiscal para 2026</a>
+        </body></html>
+        """
+        html_annexes = """
+        <html><body>
+            <a href="/normatividad/rmf2026.pdf">Resolución Miscelánea Fiscal para 2026</a>
+            <a href="/normatividad/anexo1.pdf">Anexo 1 RMF 2026</a>
+        </body></html>
+        """
+
+        def _fake_get(url):
+            resp = MagicMock()
+            resp.text = html_annexes if "22703" in url else html_main
+            return resp
+
+        mock_get.side_effect = _fake_get
+
+        documents = scraper.discover(year=2026, include_annexes=True)
+        official_ids = [d.official_id for d in documents]
+        assert official_ids.count("rmf_2026") == 1, "Annual RMF should be deduped"
+        assert "rmf_2026_anexo_1" in official_ids
+
+    @patch.object(RmfScraper, "_get")
+    def test_returns_empty_when_indices_unreachable(self, mock_get, scraper):
+        mock_get.return_value = None  # both pages 5xx / timeout
+        documents = scraper.discover(year=2026, include_annexes=True)
+        assert documents == []
+
+    @patch.object(RmfScraper, "_get")
+    def test_skips_annexes_index_when_disabled(self, mock_get, scraper):
+        mock_get.return_value = MagicMock(text="<html></html>")
+        scraper.discover(year=2026, include_annexes=False)
+        # Only the main index should have been hit
+        called_urls = [call.args[0] for call in mock_get.call_args_list]
+        assert all("22702" in url for url in called_urls), called_urls
+
+
+class TestRun:
+    """run() coordinates discover + write_catalog (+ optional download)."""
+
+    @patch.object(RmfScraper, "discover")
+    def test_run_writes_catalog_even_when_empty(self, mock_discover, scraper):
+        mock_discover.return_value = []
+        result = scraper.run(year=2026, download_documents=False)
+        assert result["total"] == 0
+        assert result["downloaded"] == 0
+        assert (scraper.output_dir / "catalog.json").exists()
+
+    @patch.object(RmfScraper, "download")
+    @patch.object(RmfScraper, "discover")
+    def test_run_downloads_when_requested(
+        self, mock_discover, mock_download, scraper, tmp_path
+    ):
+        doc = RmfDocument(
+            official_id="rmf_2026",
+            name="Resolución Miscelánea Fiscal 2026",
+            url="https://www.sat.gob.mx/.../rmf2026.pdf",
+            document_type="rmf",
+            year=2026,
+        )
+        mock_discover.return_value = [doc]
+        mock_download.return_value = tmp_path / "rmf_2026.pdf"
+
+        result = scraper.run(year=2026, download_documents=True)
+        assert result["total"] == 1
+        assert result["downloaded"] == 1
+        assert mock_download.called
+
+    @patch.object(RmfScraper, "discover")
+    def test_run_summary_groups_by_type(self, mock_discover, scraper):
+        mock_discover.return_value = [
+            RmfDocument(
+                official_id="rmf_2026",
+                name="RMF 2026",
+                url="x",
+                document_type="rmf",
+                year=2026,
+            ),
+            RmfDocument(
+                official_id="rmf_2026_modificacion_1",
+                name="1ra Mod",
+                url="y",
+                document_type="modification",
+                year=2026,
+            ),
+            RmfDocument(
+                official_id="rmf_2026_anexo_1",
+                name="Anexo 1",
+                url="z",
+                document_type="annex",
+                year=2026,
+            ),
+            RmfDocument(
+                official_id="rmf_2026_anexo_14",
+                name="Anexo 14",
+                url="w",
+                document_type="annex",
+                year=2026,
+            ),
+        ]
+        result = scraper.run(year=2026, download_documents=False)
+        assert result["by_type"]["rmf"] == 1
+        assert result["by_type"]["modification"] == 1
+        assert result["by_type"]["annex"] == 2
+
+
+class TestRmfDocument:
+    """Sanity for the dataclass — domains list defaults are independent."""
+
+    def test_default_domains_is_independent_per_instance(self):
+        a = RmfDocument(
+            official_id="a",
+            name="A",
+            url="https://example.com/a",
+            document_type="rmf",
+            year=2026,
+        )
+        b = RmfDocument(
+            official_id="b",
+            name="B",
+            url="https://example.com/b",
+            document_type="rmf",
+            year=2026,
+        )
+        a.domains.append("custom")
+        assert (
+            "custom" not in b.domains
+        ), "Mutable default leaked across RmfDocument instances"


### PR DESCRIPTION
## Summary

Track 1 of the [FEATURE_PARITY_PLAN_2026-04-27](docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md) (§3.6). Replaces the 99-line stub deleted in `90294b1` with a working SAT-portal scraper for Karafiel's compliance feed.

**Why now:** Karafiel's compliance use case (per §3.4) needs SAT regulatory freshness. Without RMF + quarterly modifications + annexes the \"fiscal-alerts\" pitch is hollow. RMF + Rule 2.9.21 (digital-platform API requirements) are the corpus Karafiel needs.

## What ships

| File | Purpose |
|---|---|
| `apps/scraper/federal/rmf_scraper.py` | `RmfScraper` class — requests-first, classify-then-dedup across 2 SAT index pages |
| `apps/api/management/commands/ingest_rmf.py` | Catalog → Law + LawVersion upsert, tagged `domains=[\"fiscal\"]` for Karafiel webhook filter |
| `apps/scraper/scheduling/tasks.py` | `dataops.run_rmf_scraper` Celery task |
| `apps/indigo/settings.py` | `rmf-quarterly-scrape` beat schedule: 03:00 on 8th of Jan/Apr/Jul/Oct (offset from DOF quarterly) |
| `tests/scraper/test_rmf_scraper.py` | 20 network-free unit tests |

## Done criterion (plan §3.6)

- [x] Scraper class with `discover` + `download` + `run` + `write_catalog`
- [x] Quarterly Celery beat task
- [x] Ingest pathway → Law + LawVersion with `domains=[\"fiscal\"]`
- [x] 20/20 unit tests pass
- [x] Full pytest suite: **1463 passed** (1443 baseline + 20), 0 failures
- [x] black + isort clean

Live RMF + Annex 1 verification happens post-deploy on the next quarterly Beat tick (or earlier via manual run).

## Test plan

- [x] `poetry run pytest tests/scraper/test_rmf_scraper.py -v` — 20 passed
- [x] `poetry run pytest tests/` — 1463 passed, 0 regressions
- [x] `poetry run black --check` on touched files — clean
- [x] `poetry run isort --check-only` on touched files — clean
- [ ] Manual run post-deploy: `enclii jobs run rmf-quarterly-scrape`
- [ ] Verify catalog has at least the annual 2026 RMF + Anexo 1
- [ ] `python manage.py ingest_rmf --catalog data/rmf/catalog.json --dry-run`
- [ ] `python manage.py index_laws --law-id rmf_2026` to ES

🤖 Generated with [Claude Code](https://claude.com/claude-code)