### PR TITLE
feat(chat): /preguntar AI assistant scaffold (Selva-routed, behind flag)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,26 @@ JANUA_SECRET_KEY=                   # jns_* from seed output (tezca-web)
 # default unless tuning the parser pipeline.
 QUALITY_QUARANTINE_GRADES=D,F
 
+# ── First-party AI assistant (/preguntar) ─────────────────────────────
+# Master kill-switch for the chat endpoint. Defaults to false so the
+# scaffold can ship without the route being live. Flip to "true" once
+# Selva onboarding (cross-cutting Track 8) lands.
+CHAT_ENABLED=false
+# Selva client backend selection. "mock" returns deterministic canned
+# responses (default; safe for dev + tests). "selva" forwards to the
+# OpenAI-compatible /v1/chat/completions endpoint declared below.
+CHAT_BACKEND=mock
+# Required when CHAT_BACKEND=selva. Post-cutover this becomes
+# https://api.selva.town/v1 per RFC 0010 Layer 2.
+SELVA_API_URL=https://agents-api.madfam.io/v1
+# Janua-relayed bearer token for the tezca service account on Selva.
+# Provisioned via the Selva onboarding ticket; rotate per the standard
+# Janua client-credentials flow.
+SELVA_API_TOKEN=
+# Default model for chat completions. Cheapest model that fits the
+# typical RAG context window.
+SELVA_DEFAULT_MODEL=claude-haiku-4-5
+
 # ── Billing (Dhanam) ──────────────────────────────────────────────────
 # Checkout URL the frontend redirects users to for tier purchases.
 DHANAM_CHECKOUT_URL=https://dhanam.madfam.io/checkout

--- a/apps/api/chat/__init__.py
+++ b/apps/api/chat/__init__.py
@@ -1,0 +1,25 @@
+"""
+First-party AI assistant ("Pregunta a Tezca") — Track 2 of
+FEATURE_PARITY_PLAN_2026-04-27 §3.1.
+
+Architecture (per the plan's strict constraint contract):
+- Tezca never holds an OpenAI/Anthropic API key.
+- Every LLM call routes through Selva (`agents-api.madfam.io/v1`,
+  OpenAI-compatible) per the MADFAM ECOSYSTEM convention.
+- LLM costs are billed via Dhanam metered agent-hours, not per Tezca tier.
+
+Tezca-side responsibilities:
+1. Retrieve relevant article snippets via ES + cross-references.
+2. Build the system prompt with the corpus snippets.
+3. Forward to Selva and stream/return the response.
+4. Enforce per-tier daily message budgets via APIUsageLog accounting.
+
+Components:
+- ``selva_client`` — HTTP client wrapper. Real + mock implementations.
+- ``retriever``    — RAG retrieval over the existing ES index.
+- ``views``        — DRF view at POST /api/v1/chat/preguntar/
+"""
+
+from .selva_client import MockSelvaClient, SelvaClient, get_selva_client
+
+__all__ = ["MockSelvaClient", "SelvaClient", "get_selva_client"]

--- a/apps/api/chat/retriever.py
+++ b/apps/api/chat/retriever.py
@@ -1,0 +1,187 @@
+"""
+RAG retriever for the ``/preguntar`` chat.
+
+Retrieves the top-K most relevant article snippets for a user query by
+running a BM25 search against the existing ``articles`` ES index, then
+optionally hydrates them with cross-reference metadata so the LLM can
+quote outgoing references.
+
+Design notes:
+- We deliberately **do not** add a vector-search backend here. Tezca's
+  ES index uses BM25 + function-score recency boost (per CLAUDE.md
+  "Search relevance"); that's strong enough for the v1 chat. Vector
+  retrieval is a separate roadmap item.
+- Failure mode: if ES is degraded the retriever returns an empty
+  context, the chat view replies politely without citations rather than
+  hallucinate. Mirrors the existing graceful-degradation pattern in
+  ``law_views``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List, Optional
+
+from apps.api.config import INDEX_NAME, es_client
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RetrievedSnippet:
+    """One article snippet returned from BM25 retrieval."""
+
+    law_id: str
+    law_name: str
+    article_id: str
+    text: str
+    score: float
+
+    def citation(self) -> str:
+        """Inline citation string used in the LLM system prompt."""
+        return f"[{self.law_id}#{self.article_id}]"
+
+    def link(self) -> str:
+        """Frontend link for the chat UI."""
+        return f"/leyes/{self.law_id}#article-{self.article_id}"
+
+
+def retrieve(
+    query: str,
+    *,
+    top_k: int = 5,
+    snippet_max_chars: int = 800,
+) -> List[RetrievedSnippet]:
+    """BM25 retrieval against the ``articles`` index.
+
+    Returns up to ``top_k`` snippets, each truncated to
+    ``snippet_max_chars`` so the system-prompt context stays bounded.
+    On ES failure returns ``[]`` — the caller handles the empty case.
+    """
+    if not query or not query.strip():
+        return []
+
+    body = {
+        "size": top_k,
+        "query": {
+            "multi_match": {
+                "query": query,
+                "fields": ["text^1", "law_name^2"],
+                "type": "best_fields",
+            }
+        },
+        "_source": ["law_id", "law_name", "article_id", "text"],
+    }
+
+    try:
+        response = es_client.search(index=INDEX_NAME, body=body)
+    except Exception:
+        logger.exception("ES retrieval failed for chat query")
+        return []
+
+    hits = response.get("hits", {}).get("hits", [])
+    snippets: List[RetrievedSnippet] = []
+    for hit in hits:
+        src = hit.get("_source", {})
+        text = (src.get("text") or "").strip()
+        if not text:
+            continue
+        snippets.append(
+            RetrievedSnippet(
+                law_id=src.get("law_id", ""),
+                law_name=src.get("law_name", ""),
+                article_id=src.get("article_id", ""),
+                text=_truncate(text, snippet_max_chars),
+                score=float(hit.get("_score", 0.0)),
+            )
+        )
+    return snippets
+
+
+def build_system_prompt(snippets: List[RetrievedSnippet]) -> str:
+    """Compose the system prompt that grounds the LLM in retrieved snippets.
+
+    The prompt is in Spanish because Tezca's primary user is a Spanish
+    speaker — but it instructs the model to answer in the user's
+    language. The model is told to cite via ``[law_id#article_id]`` so
+    the chat UI can convert citations into clickable links via the
+    same regex.
+    """
+    if not snippets:
+        return _SYSTEM_PROMPT_NO_CONTEXT
+
+    citations_block = "\n\n".join(
+        f"### {s.citation()} — {s.law_name}, Artículo {s.article_id}\n{s.text}"
+        for s in snippets
+    )
+    return _SYSTEM_PROMPT_TEMPLATE.format(citations=citations_block)
+
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+Eres Tezca, un asistente legal mexicano especializado en derecho federal,
+estatal y municipal. Respondes preguntas usando ÚNICAMENTE los artículos
+citados en CONTEXTO. Si la respuesta no está en CONTEXTO, dilo
+claramente; no inventes referencias.
+
+Reglas de citación:
+- Cada afirmación legal debe ir acompañada de su cita en formato
+  [law_id#article_id].
+- No inventes artículos ni cambies sus números.
+- Responde en el idioma de la pregunta del usuario.
+
+CONTEXTO (artículos relevantes):
+
+{citations}
+
+Si la pregunta es ambigua, pide aclaración antes de responder.
+"""
+
+_SYSTEM_PROMPT_NO_CONTEXT = """\
+Eres Tezca, un asistente legal mexicano. No encontré artículos relevantes
+en el corpus para esta pregunta. Responde brevemente que necesitas más
+contexto o que la consulta podría no estar en el corpus mexicano que
+indexamos. No inventes citas.
+"""
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    """Truncate ``text`` to ``max_chars``, preserving word boundaries."""
+    if len(text) <= max_chars:
+        return text
+    cut = text[:max_chars].rsplit(" ", 1)[0]
+    return cut + "…"
+
+
+def extract_referenced_articles(
+    snippets: List[RetrievedSnippet],
+) -> List[dict]:
+    """Build the citation list the chat UI renders next to the answer.
+
+    Each citation links back to ``/leyes/{law_id}#article-{article_id}``,
+    which is the same anchor pattern used by ``LinkifiedArticle`` so the
+    user lands on the exact article when they click through.
+    """
+    seen: set[str] = set()
+    citations: List[dict] = []
+    for s in snippets:
+        key = f"{s.law_id}#{s.article_id}"
+        if key in seen:
+            continue
+        seen.add(key)
+        citations.append(
+            {
+                "law_id": s.law_id,
+                "law_name": s.law_name,
+                "article_id": s.article_id,
+                "url": s.link(),
+            }
+        )
+    return citations
+
+
+def retrieval_disabled(reason: Optional[str] = None) -> List[RetrievedSnippet]:
+    """Sentinel for callers that want to stub retrieval entirely (tests)."""
+    if reason:
+        logger.info("Chat retrieval disabled: %s", reason)
+    return []

--- a/apps/api/chat/selva_client.py
+++ b/apps/api/chat/selva_client.py
@@ -1,0 +1,207 @@
+"""
+Selva client — Tezca's gateway to the MADFAM-wide LLM router.
+
+Per ``internal-devops/ECOSYSTEM.md``: every LLM call should route through
+Selva (`selva-office`, formerly `autoswarm-office`) at ``/v1``
+(OpenAI-compatible). Tezca never holds an OpenAI / Anthropic API key.
+
+Two implementations:
+
+* ``SelvaClient`` — production. POSTs to ``$SELVA_API_URL/chat/completions``
+  with a Janua-relayed bearer token. Returns the response message + usage.
+* ``MockSelvaClient`` — deterministic. Used in tests and any environment
+  where ``SELVA_API_URL`` is unset. Returns a templated answer derived from
+  the input messages so test assertions can be exact.
+
+The active client is selected by ``CHAT_BACKEND`` env var (``selva`` |
+``mock``), defaulting to ``mock`` so a fresh dev box doesn't accidentally
+hit production Selva.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Protocol
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChatMessage:
+    """A single message in a chat completion request/response."""
+
+    role: str  # "system" | "user" | "assistant"
+    content: str
+
+
+@dataclass
+class ChatCompletion:
+    """Selva's chat-completion response, normalized to what Tezca needs."""
+
+    message: ChatMessage
+    prompt_tokens: int
+    completion_tokens: int
+    model: str
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+class _SelvaClientProtocol(Protocol):
+    """Minimal contract every Selva client implementation must satisfy."""
+
+    def chat_completion(
+        self,
+        messages: List[ChatMessage],
+        *,
+        model: Optional[str] = None,
+        temperature: float = 0.2,
+        max_tokens: int = 1024,
+    ) -> ChatCompletion: ...
+
+
+class SelvaClient:
+    """Real Selva client — talks HTTP to the OpenAI-compatible /v1 endpoint.
+
+    Configuration:
+    - ``SELVA_API_URL`` — base URL, e.g. ``https://agents-api.madfam.io/v1``
+      (post-cutover: ``https://api.selva.town/v1``).
+    - ``SELVA_API_TOKEN`` — Janua-relayed bearer token. The Tezca service
+      account is provisioned per the §3.1 cross-cutting Selva onboarding
+      ticket.
+    - ``SELVA_DEFAULT_MODEL`` — default ``"claude-haiku-4-5"`` (cheapest
+      that handles our RAG context size).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        default_model: str = "claude-haiku-4-5",
+        timeout: float = 30.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._token = token
+        self._default_model = default_model
+        self._timeout = timeout
+        self._session = requests.Session()
+
+    def chat_completion(
+        self,
+        messages: List[ChatMessage],
+        *,
+        model: Optional[str] = None,
+        temperature: float = 0.2,
+        max_tokens: int = 1024,
+    ) -> ChatCompletion:
+        """Forward a chat-completion request to Selva.
+
+        Raises ``requests.HTTPError`` on 4xx/5xx so the caller can decide
+        whether to surface a user-facing error or retry.
+        """
+        payload: Dict[str, Any] = {
+            "model": model or self._default_model,
+            "messages": [{"role": m.role, "content": m.content} for m in messages],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        url = f"{self._base_url}/chat/completions"
+
+        resp = self._session.post(
+            url,
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+            },
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+        choice = body["choices"][0]["message"]
+        usage = body.get("usage", {})
+        return ChatCompletion(
+            message=ChatMessage(role=choice["role"], content=choice["content"]),
+            prompt_tokens=int(usage.get("prompt_tokens", 0)),
+            completion_tokens=int(usage.get("completion_tokens", 0)),
+            model=body.get("model", payload["model"]),
+        )
+
+
+class MockSelvaClient:
+    """Deterministic stand-in for tests + environments without Selva.
+
+    Returns a canned reply derived from the inputs so tests can assert
+    exact substrings. Token counts are heuristic (≈ 1 token per 4 chars
+    of input + a fixed completion length).
+    """
+
+    def __init__(self, default_model: str = "mock-model") -> None:
+        self._default_model = default_model
+
+    def chat_completion(
+        self,
+        messages: List[ChatMessage],
+        *,
+        model: Optional[str] = None,
+        temperature: float = 0.2,
+        max_tokens: int = 1024,
+    ) -> ChatCompletion:
+        # The deterministic reply echoes the last user turn so retrieval +
+        # RAG-context-injection tests can assert that the prompt was built
+        # correctly without depending on a real LLM.
+        user_turn = next(
+            (m.content for m in reversed(messages) if m.role == "user"), ""
+        )
+        canned = (
+            f"[mock-selva] Recibí tu pregunta: «{user_turn[:120]}». "
+            "En producción Selva enrutará a un LLM real con citas a artículos."
+        )
+
+        prompt_chars = sum(len(m.content) for m in messages)
+        prompt_tokens = max(1, prompt_chars // 4)
+        completion_tokens = max(1, len(canned) // 4)
+
+        return ChatCompletion(
+            message=ChatMessage(role="assistant", content=canned),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=model or self._default_model,
+        )
+
+
+def get_selva_client() -> _SelvaClientProtocol:
+    """Return the configured Selva client.
+
+    Selection rule:
+    - ``CHAT_BACKEND=selva`` → real ``SelvaClient`` (raises if env missing).
+    - ``CHAT_BACKEND=mock`` (default) → ``MockSelvaClient``.
+
+    Tests always get ``MockSelvaClient`` unless they explicitly inject a
+    real one. Production deploys flip ``CHAT_BACKEND=selva`` once the
+    Selva onboarding ticket lands.
+    """
+    backend = os.getenv("CHAT_BACKEND", "mock").lower()
+
+    if backend == "selva":
+        base_url = os.getenv("SELVA_API_URL")
+        token = os.getenv("SELVA_API_TOKEN")
+        if not base_url or not token:
+            logger.error(
+                "CHAT_BACKEND=selva but SELVA_API_URL/SELVA_API_TOKEN missing — "
+                "falling back to MockSelvaClient"
+            )
+            return MockSelvaClient()
+        return SelvaClient(
+            base_url=base_url,
+            token=token,
+            default_model=os.getenv("SELVA_DEFAULT_MODEL", "claude-haiku-4-5"),
+        )
+
+    return MockSelvaClient()

--- a/apps/api/chat/views.py
+++ b/apps/api/chat/views.py
@@ -1,0 +1,236 @@
+"""
+``POST /api/v1/chat/preguntar/`` — first-party AI assistant endpoint.
+
+Gating layers (in order):
+
+1. ``CHAT_ENABLED`` env feature flag. When ``false`` (default), the
+   endpoint returns 503. Lets us merge code without exposing the route.
+2. Authenticated user (any tier with ``api_key_access``). Anonymous +
+   ``free_member`` get 401/403 from the existing auth stack.
+3. ``RequireFeature.of("chat")`` — only ``essentials+`` per
+   ``apps/api/tiers.json``.
+4. Daily-message budget per tier (``chat_messages_per_day``). Enforced
+   via ``APIUsageLog`` rows tagged ``endpoint='chat.preguntar'``.
+
+Body shape::
+
+    POST /api/v1/chat/preguntar/
+    Content-Type: application/json
+    X-API-Key: tzk_...
+
+    {"question": "..."}
+
+Response::
+
+    {
+      "answer": "...",
+      "citations": [
+        {"law_id": "cpeum", "law_name": "Constitución...", "article_id": "31", "url": "/leyes/cpeum#article-31"},
+        ...
+      ],
+      "usage": {"prompt_tokens": 1234, "completion_tokens": 200, "total_tokens": 1434, "model": "..."}
+    }
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+from typing import Any, Dict
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from apps.api.middleware.tier_permissions import RequireFeature, get_tier_limits
+from apps.api.models import APIUsageLog
+from apps.api.tier_permissions import get_effective_tier
+
+from .retriever import build_system_prompt, extract_referenced_articles, retrieve
+from .selva_client import ChatMessage, get_selva_client
+
+logger = logging.getLogger(__name__)
+
+# Bound how much corpus context we ship per request — keeps the system
+# prompt under typical 8K-token windows even on long-text articles.
+_RETRIEVAL_TOP_K = 5
+_SNIPPET_MAX_CHARS = 800
+
+# Cap user input length so a malicious caller can't blow our token budget
+# in a single request before the daily-budget check runs.
+_MAX_QUESTION_CHARS = 2000
+
+# tiers.json key for daily-budget enforcement
+_BUDGET_KEY = "chat_messages_per_day"
+
+
+def _chat_enabled() -> bool:
+    return os.getenv("CHAT_ENABLED", "false").lower() in ("true", "1", "yes")
+
+
+def _today_utc_start() -> datetime.datetime:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _budget_for_tier(tier: str) -> int:
+    """Daily message budget for ``tier``. -1 means unlimited."""
+    return int(get_tier_limits(tier).get(_BUDGET_KEY, 0))
+
+
+def _used_today(api_key_prefix: str) -> int:
+    """Count chat.preguntar calls for this api-key prefix since 00:00 UTC."""
+    if not api_key_prefix:
+        return 0
+    return APIUsageLog.objects.filter(
+        api_key_prefix=api_key_prefix,
+        endpoint="chat.preguntar",
+        created_at__gte=_today_utc_start(),
+    ).count()
+
+
+def _record_usage(
+    api_key_prefix: str,
+    ip_address: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+) -> None:
+    """Log a chat call to APIUsageLog so the daily-budget check sees it.
+
+    Token counts are intentionally not persisted on the row — APIUsageLog
+    has no metadata column today. The endpoint name + count is enough
+    for the v1 budget enforcement; richer telemetry goes to logs.
+    """
+    APIUsageLog.objects.create(
+        api_key_prefix=api_key_prefix,
+        ip_address=ip_address or "0.0.0.0",
+        endpoint="chat.preguntar",
+        method="POST",
+        status_code=200,
+    )
+    logger.info(
+        "chat.preguntar usage api_key=%s prompt_tokens=%d completion_tokens=%d",
+        api_key_prefix or "anon",
+        prompt_tokens,
+        completion_tokens,
+    )
+
+
+@extend_schema(
+    tags=["Chat"],
+    summary="Ask Tezca a legal question (RAG over the corpus, LLM via Selva)",
+    description=(
+        "First-party AI assistant. Retrieves relevant articles from the "
+        "Tezca corpus and forwards them to Selva for grounded generation. "
+        "Gated behind CHAT_ENABLED feature flag and `essentials+` tier."
+    ),
+)
+@api_view(["POST"])
+@permission_classes([RequireFeature.of("chat")])
+def preguntar(request: Request) -> Response:
+    """Handle a single chat question."""
+    # Layer 1: global feature flag
+    if not _chat_enabled():
+        return Response(
+            {"error": "Chat is not enabled in this environment."},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    # Layer 2: must have an authenticated user with a Janua user_id.
+    # The combined-auth middleware populates request.user; api-key users
+    # get a janua_user_id via the APIKey row.
+    user = getattr(request, "user", None)
+    if not user or not getattr(user, "is_authenticated", False):
+        return Response(
+            {"error": "Authentication required."},
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+    api_key_prefix = getattr(user, "api_key_prefix", "")
+
+    # Layer 3 already handled by RequireFeature; pull tier for budgeting.
+    tier = get_effective_tier(getattr(user, "tier", None) or "anon")
+    budget = _budget_for_tier(tier)
+
+    # Layer 4: daily-budget check
+    if budget != -1:
+        used = _used_today(api_key_prefix)
+        if used >= budget:
+            return Response(
+                {
+                    "error": "Daily chat budget exhausted.",
+                    "tier": tier,
+                    "limit": budget,
+                    "resets_at": (
+                        _today_utc_start() + datetime.timedelta(days=1)
+                    ).isoformat(),
+                },
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+
+    # Validate body
+    body: Dict[str, Any] = request.data if isinstance(request.data, dict) else {}
+    question = (body.get("question") or "").strip()
+    if not question:
+        return Response(
+            {"error": "Body must include a non-empty `question` field."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    if len(question) > _MAX_QUESTION_CHARS:
+        return Response(
+            {
+                "error": (
+                    f"Question is too long (max {_MAX_QUESTION_CHARS} characters)."
+                )
+            },
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # RAG retrieval (failure-tolerant — empty context is acceptable)
+    snippets = retrieve(
+        question, top_k=_RETRIEVAL_TOP_K, snippet_max_chars=_SNIPPET_MAX_CHARS
+    )
+
+    system_prompt = build_system_prompt(snippets)
+    messages = [
+        ChatMessage(role="system", content=system_prompt),
+        ChatMessage(role="user", content=question),
+    ]
+
+    # Forward to Selva
+    client = get_selva_client()
+    try:
+        completion = client.chat_completion(messages)
+    except Exception:
+        logger.exception("Selva chat completion failed")
+        return Response(
+            {"error": "El asistente está temporalmente no disponible."},
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
+
+    # Record usage AFTER success so failed calls don't burn budget.
+    if api_key_prefix:
+        try:
+            _record_usage(
+                api_key_prefix,
+                request.META.get("REMOTE_ADDR", ""),
+                completion.prompt_tokens,
+                completion.completion_tokens,
+            )
+        except Exception:
+            logger.exception("Failed to record chat usage")
+
+    return Response(
+        {
+            "answer": completion.message.content,
+            "citations": extract_referenced_articles(snippets),
+            "usage": {
+                "prompt_tokens": completion.prompt_tokens,
+                "completion_tokens": completion.completion_tokens,
+                "total_tokens": completion.total_tokens,
+                "model": completion.model,
+            },
+        }
+    )

--- a/apps/api/tiers.json
+++ b/apps/api/tiers.json
@@ -70,7 +70,9 @@
     "webhooks": false,
     "graph_api": false,
     "annotations": true,
-    "newsletter": true
+    "newsletter": true,
+    "chat": true,
+    "chat_messages_per_day": 30
   },
   "academic": {
     "search_results_per_query": 100,
@@ -88,7 +90,9 @@
     "webhooks": false,
     "graph_api": false,
     "annotations": true,
-    "newsletter": true
+    "newsletter": true,
+    "chat": true,
+    "chat_messages_per_day": 100
   },
   "institutional": {
     "search_results_per_query": 1000,
@@ -106,7 +110,9 @@
     "webhooks": true,
     "graph_api": true,
     "annotations": true,
-    "newsletter": true
+    "newsletter": true,
+    "chat": true,
+    "chat_messages_per_day": 1000
   },
   "madfam": {
     "search_results_per_query": 1000,
@@ -124,7 +130,9 @@
     "webhooks": true,
     "graph_api": true,
     "annotations": true,
-    "newsletter": true
+    "newsletter": true,
+    "chat": true,
+    "chat_messages_per_day": -1
   },
   "internal": {
     "search_results_per_query": 50,

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -24,6 +24,7 @@ from .apikey_views import create_api_key, list_api_keys, revoke_api_key, update_
 from .billing_views import billing_webhook
 from .bulk_views import bulk_articles
 from .changelog_views import changelog
+from .chat.views import preguntar
 from .contribution_views import (
     list_contributions,
     submit_contribution,
@@ -198,6 +199,8 @@ urlpatterns = [
     path("suggest/", suggest, name="law-suggest"),
     # ── Bulk data access (API key required) ──────────────────────────────
     path("bulk/articles/", bulk_articles, name="bulk-articles"),
+    # ── Chat (essentials+ tier required, gated by CHAT_ENABLED env) ──────
+    path("chat/preguntar/", preguntar, name="chat-preguntar"),
     path("changelog/", changelog, name="changelog"),
     path("coverage/", public_coverage, name="public-coverage"),
     path("graph/overview/", graph_overview, name="graph-overview"),

--- a/tests/api/test_chat.py
+++ b/tests/api/test_chat.py
@@ -1,0 +1,317 @@
+"""
+Tests for the /api/v1/chat/preguntar/ endpoint and its components.
+
+Covers (in priority order):
+1. Feature-flag gating (CHAT_ENABLED)
+2. Tier gating (community/free_member → 403, essentials+ → 200)
+3. Selva-client selection (mock by default; selva env switch)
+4. Retriever fail-tolerance (ES down → empty context, no exception)
+5. Daily-budget enforcement (429 once limit hit)
+6. Citation extraction + dedup
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.api.chat.retriever import (
+    RetrievedSnippet,
+    build_system_prompt,
+    extract_referenced_articles,
+    retrieve,
+)
+from apps.api.chat.selva_client import (
+    ChatMessage,
+    MockSelvaClient,
+    SelvaClient,
+    get_selva_client,
+)
+from apps.api.middleware.apikey_auth import APIKeyUser
+
+AUTH_PATCH = "apps.api.middleware.combined_auth.CombinedAuthentication.authenticate"
+
+
+def _make_user(tier="essentials", prefix="chatpfx1"):
+    mock_key = MagicMock()
+    mock_key.prefix = prefix
+    mock_key.owner_email = "chat@example.com"
+    mock_key.name = "Chat Test Key"
+    mock_key.tier = tier
+    mock_key.scopes = ["read", "search"]
+    mock_key.allowed_domains = []
+    return APIKeyUser(mock_key)
+
+
+# ── MockSelvaClient ────────────────────────────────────────────────────
+
+
+class TestMockSelvaClient:
+    def test_returns_canned_response_echoing_user_turn(self):
+        client = MockSelvaClient()
+        messages = [
+            ChatMessage(role="system", content="You are Tezca."),
+            ChatMessage(role="user", content="¿Qué dice el Artículo 31?"),
+        ]
+        completion = client.chat_completion(messages)
+        assert completion.message.role == "assistant"
+        assert "Artículo 31" in completion.message.content
+
+    def test_token_counts_are_nonzero(self):
+        client = MockSelvaClient()
+        completion = client.chat_completion([ChatMessage(role="user", content="hola")])
+        assert completion.prompt_tokens > 0
+        assert completion.completion_tokens > 0
+        assert completion.total_tokens == (
+            completion.prompt_tokens + completion.completion_tokens
+        )
+
+
+# ── get_selva_client() backend selection ───────────────────────────────
+
+
+class TestSelvaClientFactory:
+    def test_default_returns_mock(self, monkeypatch):
+        monkeypatch.delenv("CHAT_BACKEND", raising=False)
+        client = get_selva_client()
+        assert isinstance(client, MockSelvaClient)
+
+    def test_explicit_mock_returns_mock(self, monkeypatch):
+        monkeypatch.setenv("CHAT_BACKEND", "mock")
+        assert isinstance(get_selva_client(), MockSelvaClient)
+
+    def test_selva_without_env_falls_back_to_mock(self, monkeypatch):
+        monkeypatch.setenv("CHAT_BACKEND", "selva")
+        monkeypatch.delenv("SELVA_API_URL", raising=False)
+        monkeypatch.delenv("SELVA_API_TOKEN", raising=False)
+        # Configuration error degrades to MockSelvaClient — never crash
+        # on import/startup.
+        assert isinstance(get_selva_client(), MockSelvaClient)
+
+    def test_selva_with_env_returns_real_client(self, monkeypatch):
+        monkeypatch.setenv("CHAT_BACKEND", "selva")
+        monkeypatch.setenv("SELVA_API_URL", "https://example.test/v1")
+        monkeypatch.setenv("SELVA_API_TOKEN", "test-token")
+        client = get_selva_client()
+        assert isinstance(client, SelvaClient)
+
+
+# ── Retriever ──────────────────────────────────────────────────────────
+
+
+class TestRetriever:
+    @patch("apps.api.chat.retriever.es_client")
+    def test_retrieve_returns_truncated_snippets(self, mock_es):
+        mock_es.search.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_score": 5.0,
+                        "_source": {
+                            "law_id": "cpeum",
+                            "law_name": "Constitución Política",
+                            "article_id": "31",
+                            "text": "x" * 1500,
+                        },
+                    }
+                ]
+            }
+        }
+        result = retrieve(
+            "¿Cuáles son las obligaciones?", top_k=3, snippet_max_chars=500
+        )
+        assert len(result) == 1
+        assert result[0].article_id == "31"
+        assert len(result[0].text) <= 501  # 500 + ellipsis char
+
+    @patch("apps.api.chat.retriever.es_client")
+    def test_retrieve_returns_empty_on_es_failure(self, mock_es):
+        mock_es.search.side_effect = Exception("ES is down")
+        result = retrieve("anything")
+        assert result == [], "ES failure must degrade to empty, not raise"
+
+    def test_retrieve_returns_empty_on_blank_query(self):
+        assert retrieve("") == []
+        assert retrieve("   ") == []
+
+    def test_build_system_prompt_with_no_context_uses_no_context_template(self):
+        prompt = build_system_prompt([])
+        assert "no encontré" in prompt.lower() or "no encontre" in prompt.lower()
+
+    def test_build_system_prompt_includes_citations_format(self):
+        snippets = [
+            RetrievedSnippet(
+                law_id="cpeum",
+                law_name="Constitución",
+                article_id="31",
+                text="Son obligaciones de los mexicanos…",
+                score=4.2,
+            ),
+        ]
+        prompt = build_system_prompt(snippets)
+        assert "[cpeum#31]" in prompt
+        assert "Constitución" in prompt
+
+    def test_extract_referenced_articles_dedups_by_law_and_article(self):
+        snippets = [
+            RetrievedSnippet(
+                law_id="cpeum",
+                law_name="Constitución",
+                article_id="31",
+                text="...",
+                score=4.0,
+            ),
+            RetrievedSnippet(
+                law_id="cpeum",
+                law_name="Constitución",
+                article_id="31",
+                text="duplicate",
+                score=3.0,
+            ),
+            RetrievedSnippet(
+                law_id="cpeum",
+                law_name="Constitución",
+                article_id="73",
+                text="...",
+                score=3.5,
+            ),
+        ]
+        citations = extract_referenced_articles(snippets)
+        assert len(citations) == 2
+        assert {c["article_id"] for c in citations} == {"31", "73"}
+        # URL points back to the article anchor used by LinkifiedArticle
+        assert all("article-" in c["url"] for c in citations)
+
+
+# ── Endpoint integration tests ─────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestPreguntarEndpoint:
+    def setup_method(self):
+        self.client = APIClient()
+        self.url = reverse("chat-preguntar")
+
+    def test_503_when_chat_disabled(self, monkeypatch):
+        monkeypatch.setenv("CHAT_ENABLED", "false")
+        response = self.client.post(self.url, {"question": "..."}, format="json")
+        # Either 503 (feature-flag) or 401 (auth-first) is acceptable here:
+        # the auth layer fires before the feature flag; in production both
+        # together amount to "endpoint is closed."
+        assert response.status_code in (401, 503)
+
+    @patch(AUTH_PATCH)
+    def test_blocks_essentials_below_tier(self, mock_auth, monkeypatch):
+        monkeypatch.setenv("CHAT_ENABLED", "true")
+        monkeypatch.setenv("CHAT_BACKEND", "mock")
+        # community tier doesn't have chat=true in tiers.json
+        user = _make_user(tier="community", prefix="commx001")
+        mock_auth.return_value = (user, "fake-key")
+        response = self.client.post(self.url, {"question": "x"}, format="json")
+        assert response.status_code == 403
+
+    @patch("apps.api.chat.views.retrieve")
+    @patch(AUTH_PATCH)
+    def test_essentials_tier_gets_answer(self, mock_auth, mock_retrieve, monkeypatch):
+        monkeypatch.setenv("CHAT_ENABLED", "true")
+        monkeypatch.setenv("CHAT_BACKEND", "mock")
+        user = _make_user(tier="essentials", prefix="essex001")
+        mock_auth.return_value = (user, "fake-key")
+        # Stub retriever so no ES is needed
+        mock_retrieve.return_value = [
+            RetrievedSnippet(
+                law_id="cpeum",
+                law_name="Constitución",
+                article_id="31",
+                text="Son obligaciones de los mexicanos…",
+                score=4.0,
+            )
+        ]
+
+        response = self.client.post(
+            self.url,
+            {"question": "¿Cuáles son las obligaciones de los mexicanos?"},
+            format="json",
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert "answer" in body
+        assert body["citations"] == [
+            {
+                "law_id": "cpeum",
+                "law_name": "Constitución",
+                "article_id": "31",
+                "url": "/leyes/cpeum#article-31",
+            }
+        ]
+        assert body["usage"]["total_tokens"] > 0
+
+    @patch("apps.api.chat.views.retrieve")
+    @patch(AUTH_PATCH)
+    def test_rejects_blank_question(self, mock_auth, mock_retrieve, monkeypatch):
+        monkeypatch.setenv("CHAT_ENABLED", "true")
+        user = _make_user(tier="essentials", prefix="essex002")
+        mock_auth.return_value = (user, "fake-key")
+
+        response = self.client.post(self.url, {"question": "  "}, format="json")
+        assert response.status_code == 400
+
+    @patch("apps.api.chat.views.retrieve")
+    @patch(AUTH_PATCH)
+    def test_rejects_oversize_question(self, mock_auth, mock_retrieve, monkeypatch):
+        monkeypatch.setenv("CHAT_ENABLED", "true")
+        user = _make_user(tier="essentials", prefix="essex003")
+        mock_auth.return_value = (user, "fake-key")
+
+        oversized = "x" * 2500
+        response = self.client.post(self.url, {"question": oversized}, format="json")
+        assert response.status_code == 400
+
+    @patch("apps.api.chat.views.retrieve")
+    @patch(AUTH_PATCH)
+    def test_returns_502_on_selva_failure(self, mock_auth, mock_retrieve, monkeypatch):
+        monkeypatch.setenv("CHAT_ENABLED", "true")
+        monkeypatch.setenv("CHAT_BACKEND", "mock")
+        user = _make_user(tier="essentials", prefix="essex004")
+        mock_auth.return_value = (user, "fake-key")
+        mock_retrieve.return_value = []
+
+        # Patch the client factory to return a client that raises
+        with patch("apps.api.chat.views.get_selva_client") as mock_factory:
+            failing = MagicMock()
+            failing.chat_completion.side_effect = Exception("upstream down")
+            mock_factory.return_value = failing
+
+            response = self.client.post(
+                self.url, {"question": "anything"}, format="json"
+            )
+        assert response.status_code == 502
+
+    @patch("apps.api.chat.views.retrieve")
+    @patch(AUTH_PATCH)
+    def test_429_when_daily_budget_exhausted(
+        self, mock_auth, mock_retrieve, monkeypatch
+    ):
+        """Synthesize 30 prior usage rows; the 31st request should 429."""
+        monkeypatch.setenv("CHAT_ENABLED", "true")
+        monkeypatch.setenv("CHAT_BACKEND", "mock")
+        user = _make_user(tier="essentials", prefix="essex005")
+        mock_auth.return_value = (user, "fake-key")
+        mock_retrieve.return_value = []
+
+        from apps.api.models import APIUsageLog
+
+        for _ in range(30):
+            APIUsageLog.objects.create(
+                api_key_prefix="essex005",
+                ip_address="127.0.0.1",
+                endpoint="chat.preguntar",
+                method="POST",
+                status_code=200,
+            )
+
+        response = self.client.post(self.url, {"question": "next one"}, format="json")
+        assert response.status_code == 429
+        assert response.json()["limit"] == 30


### PR DESCRIPTION
## Summary

Track 2 of [FEATURE_PARITY_PLAN_2026-04-27](docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md) (§3.1). Closes the biggest competitive parity gap vs vLex Vincent / Tirant Sof-IA / Lexius / Help-AI — every paid MX legal-tech competitor has chat-with-corpus.

**Architecture (per the plan's strict constraint contract):**
- Tezca never holds an OpenAI/Anthropic API key
- Every LLM call routes through Selva at `/v1` (OpenAI-compatible)
- LLM costs accrue to Selva's metered agent-hours, not Tezca tiers

## What ships

| File | Purpose |
|---|---|
| `apps/api/chat/selva_client.py` | `SelvaClient` (HTTP) + `MockSelvaClient` (deterministic) + env-driven factory |
| `apps/api/chat/retriever.py` | BM25 retrieval over articles ES index; failure-tolerant (ES down → empty context, polite reply) |
| `apps/api/chat/views.py` | `POST /api/v1/chat/preguntar/` with 4 gating layers: CHAT_ENABLED env, auth, tier (essentials+), daily budget |
| `apps/api/tiers.json` | `chat` + `chat_messages_per_day` budgets per tier (30/100/1000/-1) |
| `apps/api/urls.py` | route registration |
| `.env.example` | CHAT_ENABLED, CHAT_BACKEND, SELVA_API_URL/TOKEN/DEFAULT_MODEL |
| `tests/api/test_chat.py` | 19 network-free tests |

## Done criterion (plan §3.1)

- [x] Behind `CHAT_ENABLED` feature flag (defaults false)
- [x] Selva-routed (no direct OpenAI/Anthropic from tezca)
- [x] Tier-gated essentials+ via `RequireFeature`
- [x] Daily-budget throttle with UTC reset
- [x] Citations render as clickable `/leyes/{id}#article-{N}` links
- [x] 19/19 unit tests pass
- [x] Full pytest: **1482 passed** (1463 baseline + 19 new), 0 failures
- [x] black + isort clean

## Cross-cutting blocker

Track 8 (Selva onboarding ticket): Selva needs to provision \`tezca\` as a credentialed `/v1` caller before flipping `CHAT_BACKEND=selva` in production. Until then, mock client returns deterministic templated replies — safe to merge.

## Test plan

- [x] `poetry run pytest tests/api/test_chat.py -v` — 19/19 pass
- [x] `poetry run pytest tests/` — 1482/1482 pass
- [x] `poetry run black --check apps/api/chat/ tests/api/test_chat.py` — clean
- [x] `poetry run isort --check-only apps/api/chat/ tests/api/test_chat.py` — clean
- [ ] Post-deploy: smoke-test with `CHAT_ENABLED=true`, `CHAT_BACKEND=mock`, essentials API key
- [ ] After Selva onboarding: flip `CHAT_BACKEND=selva` and verify a real cited answer
- [ ] Frontend `/preguntar` chat UI lands in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)