### PR TITLE
feat(scraper): state scrapers wave 1A (Aguascalientes, Hidalgo, Morelos, Yucatán)

### DIFF
--- a/apps/scraper/scheduling/tasks.py
+++ b/apps/scraper/scheduling/tasks.py
@@ -300,6 +300,20 @@ def run_state_scraper(state_key):
         "quintana_roo": "apps.scraper.state.quintana_roo.QuintanaRooScraper",
         "guerrero": "apps.scraper.state.guerrero.GuerreroScraper",
         "nuevo_leon": "apps.scraper.state.nuevo_leon.NuevoLeonScraper",
+        # Backfill: existing modules that weren't registered in the dispatch
+        # table. Adding here makes them invokable via `enclii jobs run
+        # state-<key>` without implying a Beat schedule (those land per-state
+        # after the first manual run validates the URL guesses).
+        "cdmx": "apps.scraper.state.cdmx.CDMXScraper",
+        "estado_de_mexico": "apps.scraper.state.estado_de_mexico.EstadoDeMexicoScraper",
+        "michoacan": "apps.scraper.state.michoacan.MichoacanScraper",
+        "san_luis_potosi": "apps.scraper.state.san_luis_potosi.SanLuisPotosiScraper",
+        "zacatecas": "apps.scraper.state.zacatecas.ZacatecasScraper",
+        # Wave 1A — new scrapers from FEATURE_PARITY_PLAN_2026-04-27 §3.5
+        "aguascalientes": "apps.scraper.state.aguascalientes.AguascalientesScraper",
+        "hidalgo": "apps.scraper.state.hidalgo.HidalgoScraper",
+        "morelos": "apps.scraper.state.morelos.MorelosScraper",
+        "yucatan": "apps.scraper.state.yucatan.YucatanScraper",
     }
 
     if state_key not in scrapers:

--- a/apps/scraper/state/aguascalientes.py
+++ b/apps/scraper/state/aguascalientes.py
@@ -1,0 +1,183 @@
+"""
+Aguascalientes State Congress Scraper
+
+Scrapes legislation from the Aguascalientes state congress portal.
+Portal: https://www.congresoags.gob.mx
+Expected catalog size: ~150-200 laws.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from bs4 import BeautifulSoup
+
+from .base import StateCongressScraper
+
+logger = logging.getLogger(__name__)
+
+
+class AguascalientesScraper(StateCongressScraper):
+    """
+    Scraper for the Aguascalientes state congress website.
+
+    The catalog is typically reachable through a "Legislación" or "Marco
+    Jurídico" section that lists laws as anchor tags inside tables or
+    list elements pointing to PDF documents.
+    """
+
+    CATALOG_PATH = "/marco-juridico"
+    ALTERNATIVE_PATHS = [
+        "/legislacion",
+        "/leyes",
+        "/biblioteca-digital",
+        "/normatividad",
+        "/ws/index.php/leyes",
+    ]
+
+    def __init__(self) -> None:
+        super().__init__(
+            state="Aguascalientes",
+            base_url="https://www.congresoags.gob.mx",
+        )
+        logger.info("Initialized %s scraper - %s", self.state, self.base_url)
+
+    def scrape_catalog(self) -> List[Dict]:
+        """Walk catalog page(s) and return a deduped list of law dicts."""
+        html = self._fetch_catalog_page()
+        if not html:
+            logger.error("Could not fetch any catalog page for %s", self.state)
+            return []
+
+        soup = BeautifulSoup(html, "html.parser")
+        laws: List[Dict] = []
+        laws.extend(self._extract_from_tables(soup))
+        if not laws:
+            laws.extend(self._extract_from_lists(soup))
+        if not laws:
+            laws.extend(self._extract_all_law_links(soup))
+
+        # Deduplicate by URL
+        seen_urls: set = set()
+        unique_laws: List[Dict] = []
+        for law in laws:
+            if law["url"] not in seen_urls:
+                seen_urls.add(law["url"])
+                unique_laws.append(law)
+
+        logger.info("Scraped %d laws from %s", len(unique_laws), self.state)
+        return unique_laws
+
+    def scrape_law_content(self, url: str) -> Optional[Dict]:
+        """Download law content into the per-state raw directory."""
+        return self.download_file(url, "data/state/aguascalientes/raw")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _fetch_catalog_page(self) -> Optional[str]:
+        primary_url = self.normalize_url(self.CATALOG_PATH)
+        html = self.fetch_page(primary_url)
+        if html:
+            return html
+        logger.warning(
+            "Primary catalog path failed (%s), trying alternatives", primary_url
+        )
+        for alt_path in self.ALTERNATIVE_PATHS:
+            alt_url = self.normalize_url(alt_path)
+            html = self.fetch_page(alt_url)
+            if html:
+                logger.info("Found catalog at alternative path: %s", alt_url)
+                return html
+        return None
+
+    def _extract_from_tables(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for table in soup.find_all("table"):
+            for row in table.find_all("tr"):
+                try:
+                    for link in row.find_all("a", href=True):
+                        law = self._parse_link(link, row)
+                        if law:
+                            laws.append(law)
+                except Exception as e:  # pragma: no cover — defensive
+                    logger.debug("Error parsing table row: %s", e)
+        return laws
+
+    def _extract_from_lists(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for ul in soup.find_all(["ul", "ol"]):
+            for li in ul.find_all("li"):
+                try:
+                    link = li.find("a", href=True)
+                    if link:
+                        law = self._parse_link(link, li)
+                        if law:
+                            laws.append(law)
+                except Exception as e:  # pragma: no cover — defensive
+                    logger.debug("Error parsing list item: %s", e)
+        return laws
+
+    def _extract_all_law_links(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for link in soup.find_all("a", href=True):
+            try:
+                law = self._parse_link(link)
+                if law:
+                    laws.append(law)
+            except Exception as e:  # pragma: no cover — defensive
+                logger.debug("Error parsing link: %s", e)
+        return laws
+
+    def _parse_link(self, link, parent_element=None) -> Optional[Dict]:
+        href = link["href"].strip()
+        text = link.get_text(strip=True)
+        if parent_element and (not text or len(text) < 10):
+            text = parent_element.get_text(strip=True)
+        if not text or len(text) < 10:
+            return None
+        absolute_url = self.normalize_url(href)
+        if not self.is_downloadable(absolute_url) and not self._is_law_keyword(text):
+            return None
+
+        law = {
+            "name": text[:500],
+            "url": absolute_url,
+            "state": self.state,
+            "tier": "state",
+            "category": self.extract_category(text),
+            "law_type": self._infer_law_type(text),
+        }
+        return law if self.validate_law_data(law) else None
+
+    @staticmethod
+    def _is_law_keyword(text: str) -> bool:
+        keywords = (
+            "ley",
+            "codigo",
+            "código",
+            "reglamento",
+            "decreto",
+            "constitución",
+            "constitucion",
+            "acuerdo",
+            "norma",
+        )
+        return any(kw in text.lower() for kw in keywords)
+
+    @staticmethod
+    def _infer_law_type(text: str) -> str:
+        t = text.lower()
+        if "constitución" in t or "constitucion" in t:
+            return "constitucion_estatal"
+        if "código" in t or "codigo" in t:
+            return "codigo"
+        if "ley orgánica" in t or "ley organica" in t:
+            return "ley_organica"
+        if "ley" in t:
+            return "ley"
+        if "reglamento" in t:
+            return "reglamento"
+        if "decreto" in t:
+            return "decreto"
+        return "otro"

--- a/apps/scraper/state/hidalgo.py
+++ b/apps/scraper/state/hidalgo.py
@@ -1,0 +1,165 @@
+"""
+Hidalgo State Congress Scraper
+
+Scrapes legislation from the Hidalgo state congress portal.
+Portal: https://www.congreso-hidalgo.gob.mx
+Expected catalog size: ~250-300 laws.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from bs4 import BeautifulSoup
+
+from .base import StateCongressScraper
+
+logger = logging.getLogger(__name__)
+
+
+class HidalgoScraper(StateCongressScraper):
+    """Scraper for the Hidalgo state congress website."""
+
+    CATALOG_PATH = "/biblioteca-legislativa"
+    ALTERNATIVE_PATHS = [
+        "/leyes",
+        "/marco-juridico",
+        "/legislacion",
+        "/index.php/biblioteca-legislativa",
+    ]
+
+    def __init__(self) -> None:
+        super().__init__(
+            state="Hidalgo",
+            base_url="https://www.congreso-hidalgo.gob.mx",
+        )
+        logger.info("Initialized %s scraper - %s", self.state, self.base_url)
+
+    def scrape_catalog(self) -> List[Dict]:
+        html = self._fetch_catalog_page()
+        if not html:
+            logger.error("Could not fetch any catalog page for %s", self.state)
+            return []
+
+        soup = BeautifulSoup(html, "html.parser")
+        laws: List[Dict] = []
+        laws.extend(self._extract_from_tables(soup))
+        if not laws:
+            laws.extend(self._extract_from_lists(soup))
+        if not laws:
+            laws.extend(self._extract_all_law_links(soup))
+
+        seen_urls: set = set()
+        unique_laws: List[Dict] = []
+        for law in laws:
+            if law["url"] not in seen_urls:
+                seen_urls.add(law["url"])
+                unique_laws.append(law)
+
+        logger.info("Scraped %d laws from %s", len(unique_laws), self.state)
+        return unique_laws
+
+    def scrape_law_content(self, url: str) -> Optional[Dict]:
+        return self.download_file(url, "data/state/hidalgo/raw")
+
+    def _fetch_catalog_page(self) -> Optional[str]:
+        primary_url = self.normalize_url(self.CATALOG_PATH)
+        html = self.fetch_page(primary_url)
+        if html:
+            return html
+        for alt_path in self.ALTERNATIVE_PATHS:
+            alt_url = self.normalize_url(alt_path)
+            html = self.fetch_page(alt_url)
+            if html:
+                logger.info("Found catalog at alternative path: %s", alt_url)
+                return html
+        return None
+
+    def _extract_from_tables(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for table in soup.find_all("table"):
+            for row in table.find_all("tr"):
+                try:
+                    for link in row.find_all("a", href=True):
+                        law = self._parse_link(link, row)
+                        if law:
+                            laws.append(law)
+                except Exception as e:  # pragma: no cover
+                    logger.debug("Error parsing table row: %s", e)
+        return laws
+
+    def _extract_from_lists(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for ul in soup.find_all(["ul", "ol"]):
+            for li in ul.find_all("li"):
+                try:
+                    link = li.find("a", href=True)
+                    if link:
+                        law = self._parse_link(link, li)
+                        if law:
+                            laws.append(law)
+                except Exception as e:  # pragma: no cover
+                    logger.debug("Error parsing list item: %s", e)
+        return laws
+
+    def _extract_all_law_links(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for link in soup.find_all("a", href=True):
+            try:
+                law = self._parse_link(link)
+                if law:
+                    laws.append(law)
+            except Exception as e:  # pragma: no cover
+                logger.debug("Error parsing link: %s", e)
+        return laws
+
+    def _parse_link(self, link, parent_element=None) -> Optional[Dict]:
+        href = link["href"].strip()
+        text = link.get_text(strip=True)
+        if parent_element and (not text or len(text) < 10):
+            text = parent_element.get_text(strip=True)
+        if not text or len(text) < 10:
+            return None
+        absolute_url = self.normalize_url(href)
+        if not self.is_downloadable(absolute_url) and not self._is_law_keyword(text):
+            return None
+        law = {
+            "name": text[:500],
+            "url": absolute_url,
+            "state": self.state,
+            "tier": "state",
+            "category": self.extract_category(text),
+            "law_type": self._infer_law_type(text),
+        }
+        return law if self.validate_law_data(law) else None
+
+    @staticmethod
+    def _is_law_keyword(text: str) -> bool:
+        keywords = (
+            "ley",
+            "codigo",
+            "código",
+            "reglamento",
+            "decreto",
+            "constitución",
+            "constitucion",
+            "acuerdo",
+            "norma",
+        )
+        return any(kw in text.lower() for kw in keywords)
+
+    @staticmethod
+    def _infer_law_type(text: str) -> str:
+        t = text.lower()
+        if "constitución" in t or "constitucion" in t:
+            return "constitucion_estatal"
+        if "código" in t or "codigo" in t:
+            return "codigo"
+        if "ley orgánica" in t or "ley organica" in t:
+            return "ley_organica"
+        if "ley" in t:
+            return "ley"
+        if "reglamento" in t:
+            return "reglamento"
+        if "decreto" in t:
+            return "decreto"
+        return "otro"

--- a/apps/scraper/state/morelos.py
+++ b/apps/scraper/state/morelos.py
@@ -1,0 +1,162 @@
+"""
+Morelos State Congress Scraper
+
+Scrapes legislation from the Morelos state congress portal.
+Portal: https://www.congresomorelos.gob.mx
+Expected catalog size: ~150-200 laws.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from bs4 import BeautifulSoup
+
+from .base import StateCongressScraper
+
+logger = logging.getLogger(__name__)
+
+
+class MorelosScraper(StateCongressScraper):
+    """Scraper for the Morelos state congress website."""
+
+    CATALOG_PATH = "/leyes"
+    ALTERNATIVE_PATHS = [
+        "/marco-juridico",
+        "/legislacion",
+        "/biblioteca-legislativa",
+        "/index.php/leyes",
+    ]
+
+    def __init__(self) -> None:
+        super().__init__(
+            state="Morelos",
+            base_url="https://www.congresomorelos.gob.mx",
+        )
+        logger.info("Initialized %s scraper - %s", self.state, self.base_url)
+
+    def scrape_catalog(self) -> List[Dict]:
+        html = self._fetch_catalog_page()
+        if not html:
+            logger.error("Could not fetch any catalog page for %s", self.state)
+            return []
+        soup = BeautifulSoup(html, "html.parser")
+        laws: List[Dict] = []
+        laws.extend(self._extract_from_tables(soup))
+        if not laws:
+            laws.extend(self._extract_from_lists(soup))
+        if not laws:
+            laws.extend(self._extract_all_law_links(soup))
+        seen: set = set()
+        unique_laws: List[Dict] = []
+        for law in laws:
+            if law["url"] not in seen:
+                seen.add(law["url"])
+                unique_laws.append(law)
+        logger.info("Scraped %d laws from %s", len(unique_laws), self.state)
+        return unique_laws
+
+    def scrape_law_content(self, url: str) -> Optional[Dict]:
+        return self.download_file(url, "data/state/morelos/raw")
+
+    def _fetch_catalog_page(self) -> Optional[str]:
+        primary_url = self.normalize_url(self.CATALOG_PATH)
+        html = self.fetch_page(primary_url)
+        if html:
+            return html
+        for alt_path in self.ALTERNATIVE_PATHS:
+            alt_url = self.normalize_url(alt_path)
+            html = self.fetch_page(alt_url)
+            if html:
+                logger.info("Found catalog at alternative path: %s", alt_url)
+                return html
+        return None
+
+    def _extract_from_tables(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for table in soup.find_all("table"):
+            for row in table.find_all("tr"):
+                try:
+                    for link in row.find_all("a", href=True):
+                        law = self._parse_link(link, row)
+                        if law:
+                            laws.append(law)
+                except Exception as e:  # pragma: no cover
+                    logger.debug("Error parsing table row: %s", e)
+        return laws
+
+    def _extract_from_lists(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for ul in soup.find_all(["ul", "ol"]):
+            for li in ul.find_all("li"):
+                try:
+                    link = li.find("a", href=True)
+                    if link:
+                        law = self._parse_link(link, li)
+                        if law:
+                            laws.append(law)
+                except Exception as e:  # pragma: no cover
+                    logger.debug("Error parsing list item: %s", e)
+        return laws
+
+    def _extract_all_law_links(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for link in soup.find_all("a", href=True):
+            try:
+                law = self._parse_link(link)
+                if law:
+                    laws.append(law)
+            except Exception as e:  # pragma: no cover
+                logger.debug("Error parsing link: %s", e)
+        return laws
+
+    def _parse_link(self, link, parent_element=None) -> Optional[Dict]:
+        href = link["href"].strip()
+        text = link.get_text(strip=True)
+        if parent_element and (not text or len(text) < 10):
+            text = parent_element.get_text(strip=True)
+        if not text or len(text) < 10:
+            return None
+        absolute_url = self.normalize_url(href)
+        if not self.is_downloadable(absolute_url) and not self._is_law_keyword(text):
+            return None
+        law = {
+            "name": text[:500],
+            "url": absolute_url,
+            "state": self.state,
+            "tier": "state",
+            "category": self.extract_category(text),
+            "law_type": self._infer_law_type(text),
+        }
+        return law if self.validate_law_data(law) else None
+
+    @staticmethod
+    def _is_law_keyword(text: str) -> bool:
+        keywords = (
+            "ley",
+            "codigo",
+            "código",
+            "reglamento",
+            "decreto",
+            "constitución",
+            "constitucion",
+            "acuerdo",
+            "norma",
+        )
+        return any(kw in text.lower() for kw in keywords)
+
+    @staticmethod
+    def _infer_law_type(text: str) -> str:
+        t = text.lower()
+        if "constitución" in t or "constitucion" in t:
+            return "constitucion_estatal"
+        if "código" in t or "codigo" in t:
+            return "codigo"
+        if "ley orgánica" in t or "ley organica" in t:
+            return "ley_organica"
+        if "ley" in t:
+            return "ley"
+        if "reglamento" in t:
+            return "reglamento"
+        if "decreto" in t:
+            return "decreto"
+        return "otro"

--- a/apps/scraper/state/yucatan.py
+++ b/apps/scraper/state/yucatan.py
@@ -1,0 +1,162 @@
+"""
+Yucatán State Congress Scraper
+
+Scrapes legislation from the Yucatán state congress portal.
+Portal: https://www.congresoyucatan.gob.mx
+Expected catalog size: ~250-300 laws.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from bs4 import BeautifulSoup
+
+from .base import StateCongressScraper
+
+logger = logging.getLogger(__name__)
+
+
+class YucatanScraper(StateCongressScraper):
+    """Scraper for the Yucatán state congress website."""
+
+    CATALOG_PATH = "/leyes"
+    ALTERNATIVE_PATHS = [
+        "/marco-juridico",
+        "/legislacion",
+        "/biblioteca-legislativa",
+        "/normatividad",
+    ]
+
+    def __init__(self) -> None:
+        super().__init__(
+            state="Yucatán",
+            base_url="https://www.congresoyucatan.gob.mx",
+        )
+        logger.info("Initialized %s scraper - %s", self.state, self.base_url)
+
+    def scrape_catalog(self) -> List[Dict]:
+        html = self._fetch_catalog_page()
+        if not html:
+            logger.error("Could not fetch any catalog page for %s", self.state)
+            return []
+        soup = BeautifulSoup(html, "html.parser")
+        laws: List[Dict] = []
+        laws.extend(self._extract_from_tables(soup))
+        if not laws:
+            laws.extend(self._extract_from_lists(soup))
+        if not laws:
+            laws.extend(self._extract_all_law_links(soup))
+        seen: set = set()
+        unique_laws: List[Dict] = []
+        for law in laws:
+            if law["url"] not in seen:
+                seen.add(law["url"])
+                unique_laws.append(law)
+        logger.info("Scraped %d laws from %s", len(unique_laws), self.state)
+        return unique_laws
+
+    def scrape_law_content(self, url: str) -> Optional[Dict]:
+        return self.download_file(url, "data/state/yucatan/raw")
+
+    def _fetch_catalog_page(self) -> Optional[str]:
+        primary_url = self.normalize_url(self.CATALOG_PATH)
+        html = self.fetch_page(primary_url)
+        if html:
+            return html
+        for alt_path in self.ALTERNATIVE_PATHS:
+            alt_url = self.normalize_url(alt_path)
+            html = self.fetch_page(alt_url)
+            if html:
+                logger.info("Found catalog at alternative path: %s", alt_url)
+                return html
+        return None
+
+    def _extract_from_tables(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for table in soup.find_all("table"):
+            for row in table.find_all("tr"):
+                try:
+                    for link in row.find_all("a", href=True):
+                        law = self._parse_link(link, row)
+                        if law:
+                            laws.append(law)
+                except Exception as e:  # pragma: no cover
+                    logger.debug("Error parsing table row: %s", e)
+        return laws
+
+    def _extract_from_lists(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for ul in soup.find_all(["ul", "ol"]):
+            for li in ul.find_all("li"):
+                try:
+                    link = li.find("a", href=True)
+                    if link:
+                        law = self._parse_link(link, li)
+                        if law:
+                            laws.append(law)
+                except Exception as e:  # pragma: no cover
+                    logger.debug("Error parsing list item: %s", e)
+        return laws
+
+    def _extract_all_law_links(self, soup: BeautifulSoup) -> List[Dict]:
+        laws: List[Dict] = []
+        for link in soup.find_all("a", href=True):
+            try:
+                law = self._parse_link(link)
+                if law:
+                    laws.append(law)
+            except Exception as e:  # pragma: no cover
+                logger.debug("Error parsing link: %s", e)
+        return laws
+
+    def _parse_link(self, link, parent_element=None) -> Optional[Dict]:
+        href = link["href"].strip()
+        text = link.get_text(strip=True)
+        if parent_element and (not text or len(text) < 10):
+            text = parent_element.get_text(strip=True)
+        if not text or len(text) < 10:
+            return None
+        absolute_url = self.normalize_url(href)
+        if not self.is_downloadable(absolute_url) and not self._is_law_keyword(text):
+            return None
+        law = {
+            "name": text[:500],
+            "url": absolute_url,
+            "state": self.state,
+            "tier": "state",
+            "category": self.extract_category(text),
+            "law_type": self._infer_law_type(text),
+        }
+        return law if self.validate_law_data(law) else None
+
+    @staticmethod
+    def _is_law_keyword(text: str) -> bool:
+        keywords = (
+            "ley",
+            "codigo",
+            "código",
+            "reglamento",
+            "decreto",
+            "constitución",
+            "constitucion",
+            "acuerdo",
+            "norma",
+        )
+        return any(kw in text.lower() for kw in keywords)
+
+    @staticmethod
+    def _infer_law_type(text: str) -> str:
+        t = text.lower()
+        if "constitución" in t or "constitucion" in t:
+            return "constitucion_estatal"
+        if "código" in t or "codigo" in t:
+            return "codigo"
+        if "ley orgánica" in t or "ley organica" in t:
+            return "ley_organica"
+        if "ley" in t:
+            return "ley"
+        if "reglamento" in t:
+            return "reglamento"
+        if "decreto" in t:
+            return "decreto"
+        return "otro"

--- a/tests/scraper/test_state_scrapers_wave1a.py
+++ b/tests/scraper/test_state_scrapers_wave1a.py
@@ -1,0 +1,209 @@
+"""
+Tests for Wave 1A state scrapers (aguascalientes, hidalgo, morelos, yucatan).
+
+Network-free: every test patches ``fetch_page`` so we never hit the live
+state portals. Verifies the four scrapers share consistent scrape +
+classification behavior with the existing baja_california / michoacan
+template.
+
+Each scraper is exercised via the same parametrized suite — adding a new
+state to ``WAVE1A_SCRAPERS`` automatically extends test coverage.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.scraper.state.aguascalientes import AguascalientesScraper
+from apps.scraper.state.hidalgo import HidalgoScraper
+from apps.scraper.state.morelos import MorelosScraper
+from apps.scraper.state.yucatan import YucatanScraper
+
+# (scraper_class, expected_state_name) tuples. Adding a Wave 1B state to
+# this list extends every test below to it.
+WAVE1A_SCRAPERS = [
+    (AguascalientesScraper, "Aguascalientes"),
+    (HidalgoScraper, "Hidalgo"),
+    (MorelosScraper, "Morelos"),
+    (YucatanScraper, "Yucatán"),
+]
+
+
+@pytest.fixture(params=WAVE1A_SCRAPERS, ids=lambda x: x[1])
+def scraper_pair(request):
+    """Yields ``(scraper_instance, expected_state_name)`` for each Wave 1A state."""
+    scraper_cls, state_name = request.param
+    return scraper_cls(), state_name
+
+
+# ── Initialization sanity ─────────────────────────────────────────────
+
+
+def test_state_name_set_correctly(scraper_pair):
+    scraper, state_name = scraper_pair
+    assert scraper.state == state_name
+
+
+def test_base_url_has_https_scheme(scraper_pair):
+    scraper, _ = scraper_pair
+    assert scraper.base_url.startswith("https://")
+
+
+def test_session_initialized(scraper_pair):
+    scraper, _ = scraper_pair
+    assert scraper.session is not None
+
+
+def test_rate_limit_configured(scraper_pair):
+    scraper, _ = scraper_pair
+    assert scraper.min_request_interval > 0
+
+
+def test_alternative_paths_present(scraper_pair):
+    """Every Wave 1A scraper provides fallback paths so a single broken link
+    doesn't kill the catalog discovery."""
+    scraper, _ = scraper_pair
+    assert hasattr(scraper, "ALTERNATIVE_PATHS")
+    assert len(scraper.ALTERNATIVE_PATHS) >= 1
+
+
+# ── Catalog scraping (network-mocked) ─────────────────────────────────
+
+
+def _sample_html(state_name: str) -> str:
+    return f"""
+    <html><body>
+      <table>
+        <tr><td><a href="/leyes/constitucion.pdf">Constitución Política del Estado de {state_name}</a></td></tr>
+        <tr><td><a href="/leyes/codigo-civil.pdf">Código Civil del Estado de {state_name}</a></td></tr>
+        <tr><td><a href="/leyes/ley-organica.pdf">Ley Orgánica del Poder Legislativo del Estado de {state_name}</a></td></tr>
+        <tr><td><a href="/leyes/reglamento-x.pdf">Reglamento Interior del H. Congreso del Estado de {state_name}</a></td></tr>
+      </table>
+    </body></html>
+    """
+
+
+def test_scrape_catalog_extracts_known_law_types(scraper_pair):
+    scraper, state_name = scraper_pair
+    with patch.object(scraper, "fetch_page", return_value=_sample_html(state_name)):
+        catalog = scraper.scrape_catalog()
+
+    assert len(catalog) >= 4
+    types = {law["law_type"] for law in catalog}
+    assert "constitucion_estatal" in types
+    assert "codigo" in types
+    assert "ley_organica" in types
+    assert "reglamento" in types
+
+
+def test_scrape_catalog_dedups_by_url(scraper_pair):
+    """If the same URL appears in multiple parser strategies, the result
+    should only contain it once."""
+    scraper, state_name = scraper_pair
+    html = f"""
+    <html><body>
+      <table>
+        <tr><td><a href="/leyes/dup.pdf">Ley Duplicada del Estado de {state_name}</a></td></tr>
+      </table>
+      <ul>
+        <li><a href="/leyes/dup.pdf">Ley Duplicada del Estado de {state_name}</a></li>
+      </ul>
+    </body></html>
+    """
+    with patch.object(scraper, "fetch_page", return_value=html):
+        catalog = scraper.scrape_catalog()
+    assert len({law["url"] for law in catalog}) == len(catalog)
+
+
+def test_scrape_catalog_returns_empty_on_unreachable_portal(scraper_pair):
+    """If both primary and alternative paths fail, return empty list — no exception."""
+    scraper, _ = scraper_pair
+    with patch.object(scraper, "fetch_page", return_value=None):
+        catalog = scraper.scrape_catalog()
+    assert catalog == []
+
+
+def test_scrape_catalog_falls_back_to_alternative_paths(scraper_pair):
+    """If the primary catalog path 404s, the scraper should walk
+    ALTERNATIVE_PATHS until one returns HTML."""
+    scraper, state_name = scraper_pair
+    call_count = {"n": 0}
+
+    def fake_fetch(url):
+        call_count["n"] += 1
+        # Fail the first call (primary path), succeed the second
+        if call_count["n"] == 1:
+            return None
+        return _sample_html(state_name)
+
+    with patch.object(scraper, "fetch_page", side_effect=fake_fetch):
+        catalog = scraper.scrape_catalog()
+
+    assert len(catalog) > 0
+    # We hit at least the primary path + 1 alternative
+    assert call_count["n"] >= 2
+
+
+# ── Field shape ───────────────────────────────────────────────────────
+
+
+def test_scraped_law_has_required_shape(scraper_pair):
+    scraper, state_name = scraper_pair
+    with patch.object(scraper, "fetch_page", return_value=_sample_html(state_name)):
+        catalog = scraper.scrape_catalog()
+
+    for law in catalog:
+        assert set(law.keys()) >= {
+            "name",
+            "url",
+            "state",
+            "tier",
+            "category",
+            "law_type",
+        }, law
+        assert law["state"] == state_name
+        assert law["tier"] == "state"
+        assert law["url"].startswith("https://")
+
+
+# ── Celery dispatch registration ──────────────────────────────────────
+
+
+def test_all_wave1a_scrapers_registered_in_dispatch_table():
+    """Every Wave 1A scraper must be addressable from the Celery task
+    so operators can invoke `dataops.run_state_scraper(state_key=...)`
+    via Enclii."""
+    # Inspect the source rather than importing — the function-local dict
+    # isn't easily reachable otherwise.
+    from pathlib import Path
+
+    tasks_src = (
+        Path(__file__).resolve().parent.parent.parent
+        / "apps"
+        / "scraper"
+        / "scheduling"
+        / "tasks.py"
+    ).read_text()
+    for state_key, _ in [
+        ("aguascalientes", None),
+        ("hidalgo", None),
+        ("morelos", None),
+        ("yucatan", None),
+    ]:
+        assert (
+            f'"{state_key}":' in tasks_src
+        ), f"State {state_key} not registered in run_state_scraper dispatch table"
+
+
+# ── Scraping content (download stub) ──────────────────────────────────
+
+
+def test_scrape_law_content_passes_through_to_download(scraper_pair):
+    scraper, _ = scraper_pair
+    with patch.object(scraper, "download_file") as mock_dl:
+        mock_dl.return_value = {"file_type": "pdf", "size_bytes": 100}
+        result = scraper.scrape_law_content("https://example.com/x.pdf")
+        assert result == {"file_type": "pdf", "size_bytes": 100}
+        # Confirm the per-state output dir is correctly namespaced
+        called_dir = mock_dl.call_args[0][1]
+        assert called_dir.startswith("data/state/")


### PR DESCRIPTION
Track 3 of FEATURE_PARITY_PLAN_2026-04-27 §3.5. Begins closing 12/32 → 32/32 state coverage gap.

## What ships

| State | Portal | Expected count |
|---|---|---|
| Aguascalientes | congresoags.gob.mx | ~150-200 |
| Hidalgo | congreso-hidalgo.gob.mx | ~250-300 |
| Morelos | congresomorelos.gob.mx | ~150-200 |
| Yucatán | congresoyucatan.gob.mx | ~250-300 |

**Coverage: 12/32 → 16/32.** Halfway to closing the parity gap.

Also backfills the dispatch table — previous version registered only 5 of 10 existing scrapers; added the 5 missing ones alongside Wave 1A. All 14 now invokable via `enclii jobs run state-<key>`.

## Done criterion (plan §3.5)

- [x] 4 new state scraper modules merged
- [x] Each registered in run_state_scraper dispatch table
- [x] 45/45 parametrized tests pass (network-free)
- [x] Full pytest: **1527 passed** (1482 baseline + 45 new), 0 failures
- [x] black + isort clean
- [ ] Per-state catalog runs validating URL guesses — happens post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)