### PR TITLE
feat(infra): CNPG migration prep + docket-watcher bootstrap kit

### DIFF
--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -134,6 +134,30 @@ WSGI_APPLICATION = "apps.indigo.wsgi.application"
 if os.environ.get("DATABASE_URL") or os.environ.get("DB_ENGINE", "").startswith(
     "django.db.backends.postgresql"
 ):
+    # Per FEATURE_PARITY_PLAN_2026-04-27 §3.2 / RFC 0012, the production
+    # Postgres is migrating to a CloudNativePG cluster (postgres-ha-rw
+    # service for writes, postgres-ha-ro for reads). The cutover requires
+    # no client code change — only DB_HOST flips to the new Service. But
+    # a few connection-pool knobs improve survival during the <60s
+    # failover window:
+    #
+    # - connect_timeout=5: fail fast on a dead primary so PgBouncer's
+    #   queue rotates rather than blocking on a TCP timeout that defaults
+    #   to system-wide minutes.
+    # - keepalives_idle=30: detect dropped connections faster than the
+    #   Linux default ~2h, so stale conns don't outlive a failover.
+    # - CONN_MAX_AGE: 0 means "no connection persistence" — Django opens
+    #   and closes a fresh connection per request. Combined with
+    #   PgBouncer transaction-pooling, this is the simplest configuration
+    #   that survives primary promotion without a Django reload.
+    _pg_options: dict = {
+        "connect_timeout": int(os.environ.get("DB_CONNECT_TIMEOUT", "5")),
+        "keepalives": 1,
+        "keepalives_idle": int(os.environ.get("DB_KEEPALIVES_IDLE", "30")),
+        "keepalives_interval": 10,
+        "keepalives_count": 3,
+    }
+
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.postgresql",
@@ -142,6 +166,8 @@ if os.environ.get("DATABASE_URL") or os.environ.get("DB_ENGINE", "").startswith(
             "PASSWORD": os.environ.get("DB_PASSWORD", ""),
             "HOST": os.environ.get("DB_HOST", "localhost"),
             "PORT": os.environ.get("DB_PORT", "5432"),
+            "CONN_MAX_AGE": int(os.environ.get("DB_CONN_MAX_AGE", "0")),
+            "OPTIONS": _pg_options,
         }
     }
 else:

--- a/docs/strategy/CNPG_MIGRATION_PREP_2026-04-27.md
+++ b/docs/strategy/CNPG_MIGRATION_PREP_2026-04-27.md
@@ -1,0 +1,136 @@
+# CNPG Migration — Tezca-Side Preparation
+
+**Last Updated:** 2026-04-27
+**Track:** Track 6 of [FEATURE_PARITY_PLAN_2026-04-27](./FEATURE_PARITY_PLAN_2026-04-27.md) §3.2.
+**Gates on:** RFC 0012 (CloudNativePG cluster) shipping in `madfam-org/enclii`. Tezca-side prep is small; this doc captures it so the cutover is a one-line env-var flip when the platform is ready.
+**Status:** Tezca-side ready (this PR). Cutover deferred to platform-side timeline (Q4-2026 per the plan).
+
+---
+
+## 1. What changes on the Tezca side
+
+The whole reason CNPG is the right shape (per RFC 0012 §2.2.5) is that **clients change nothing** except eventually the connection-string host. PgBouncer hides the topology; Django still talks to PgBouncer.
+
+The only Tezca-side changes:
+
+### 1.1 `apps/indigo/settings.py` — connection knobs (this PR)
+
+Added to the production-Postgres `DATABASES["default"]`:
+
+```python
+"CONN_MAX_AGE": int(os.environ.get("DB_CONN_MAX_AGE", "0")),
+"OPTIONS": {
+    "connect_timeout": 5,
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+},
+```
+
+Why each:
+- `connect_timeout=5` — primary promotion takes <60s per RFC 0012. Without a tight connect timeout, Django + PgBouncer queue requests against a dead primary for the kernel-default TCP-connect timeout (~2 min). 5s fails fast, queue rotates.
+- `keepalives_*` — detect dropped connections within ~60s instead of Linux's default ~2h. Without this, stale connections in a long-lived worker pool can outlive a failover and silently lose writes.
+- `CONN_MAX_AGE=0` — no connection persistence; Django opens + closes per request. This is the simplest configuration that survives primary promotion without a service reload. Trade-off: ~5ms per request for the connect roundtrip. Acceptable; we can revisit (and bump to 60s) post-cutover if PgBouncer's transaction-pooling layer needs Django's pooling out of the way.
+
+### 1.2 `enclii.yaml` — declares dependency on the `data/postgres-ha` Cluster (deferred)
+
+Once RFC 0014 zero-touch onboarding lands the `runtime.databases[]` schema, Tezca's `enclii.yaml` should declare:
+
+```yaml
+spec:
+  runtime:
+    databases:
+      - name: tezca
+        cluster: postgres-ha     # CNPG Cluster name in data namespace
+        access: read-write
+```
+
+Switchyard projects this into the K8s NetworkPolicy + ExternalSecrets that hand the tezca pods a DSN pointing at `postgres-ha-rw.data.svc.cluster.local`.
+
+This is **not** in this PR — it depends on the RFC 0014 schema being live. Tracking comment added inline in `enclii.yaml` so the next person editing it sees the intent.
+
+### 1.3 Cutover env-var flip (operator)
+
+When the CNPG cluster is live + Tezca's database has been migrated:
+
+```bash
+# Flip the host. PgBouncer continues to front the cluster — same string
+# as today plus the CNPG-managed Service.
+enclii secrets set DB_HOST="postgres-ha-rw.data.svc.cluster.local" \
+  --service tezca-api --secret
+enclii secrets set DB_HOST="postgres-ha-rw.data.svc.cluster.local" \
+  --service tezca-worker --secret
+enclii secrets set DB_HOST="postgres-ha-rw.data.svc.cluster.local" \
+  --service tezca-beat --secret
+
+enclii deploy --env production --service tezca-api
+enclii deploy --env production --service tezca-worker
+enclii deploy --env production --service tezca-beat
+```
+
+The Postgres user/password/DB-name don't change — only the host.
+
+---
+
+## 2. What does NOT change on the Tezca side
+
+- **Django models.** The CNPG primary is still Postgres 15+; all current migrations apply.
+- **Read-replica routing.** This PR does NOT use the `postgres-ha-ro` Service — a future enhancement could split read-only queries (search list, coverage stats) to the standby for additional headroom, but the v1 shape is single-Service-via-PgBouncer.
+- **Storage backend.** Cloudflare R2 (`apps/api/storage.py`) is independent of Postgres HA.
+- **Elasticsearch.** ES HA is a sister project (sister of RFC 0012). Per CLAUDE.md known gaps, it remains single-node post-cutover. Out of scope for Track 6.
+
+---
+
+## 3. Cutover runbook (when CNPG ships)
+
+This is the abbreviated Tezca-side view. The full platform-side runbook lives at `internal-devops/runbooks/postgres-failover-drill.md` (per RFC 0012 §1).
+
+### Pre-flight
+- [ ] CNPG `Cluster: postgres-ha` deployed + soaked in staging for ≥1 week (per RFC 0012 §6 cutover-window plan)
+- [ ] Tezca's database has been migrated to the CNPG cluster (`pg_dump` from old single-instance + `pg_restore` into the CNPG primary, run during a maintenance window)
+- [ ] Staging tezca cutover green for ≥48 hours
+
+### Cutover
+- [ ] Maintenance window declared on `status.tezca.mx` (~10 min budget)
+- [ ] Operator updates `DB_HOST` secret on tezca-api / tezca-worker / tezca-beat (§1.3)
+- [ ] `enclii deploy` rolls all three Deployments
+- [ ] Smoke test: hit `https://api.tezca.mx/api/v1/admin/health/`, expect 200 with `database: connected`
+- [ ] Synthetic write: fire one webhook event via `POST /api/v1/webhooks/<id>/test/`, observe Karafiel-staging receives it
+- [ ] Failover drill (per RFC 0012 §3.2): kill the CNPG primary pod; verify writes resume in <60s
+
+### Rollback
+- [ ] If anything fails, flip `DB_HOST` back to the original single-instance Service. Documented in RFC 0012 §6.
+
+---
+
+## 4. Risk register
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Tezca's `_pg_options` conflicts with PgBouncer transaction-pooling | Low | Medium | Already validated against PgBouncer's known-incompat list (autocommit, prepared statements). Our settings touch keepalives + connect_timeout only — both compatible. |
+| `CONN_MAX_AGE=0` creates connection-thrashing under load | Low | Medium | Existing tezca traffic is <10 RPS in production; PgBouncer absorbs the open/close churn. Revisit if RPS crosses ~100. |
+| Failover takes >60s (RFC 0012 §3.2 target) | Medium | Material | We accept the documented SLA caveat (Institutional 99.9% best-effort) until HA is fully soaked. Per benchmark §6.1 decision: ship Institutional with the caveat. |
+| Read-replica routing isn't enabled | Low | Low | Not a regression — same as today. Future enhancement post-cutover. |
+
+---
+
+## 5. Done criterion
+
+Per the feature-parity plan §3.2:
+
+- [x] `apps/indigo/settings.py` updated with CNPG-friendly connection knobs (this PR)
+- [ ] `enclii.yaml` declares `runtime.databases[]` dependency (gated on RFC 0014 schema landing)
+- [ ] Tezca DB migrated to `postgres-ha-rw` (gated on RFC 0012 cluster shipping)
+- [ ] Failover drill passes in production (per RFC 0012 §3.2)
+- [ ] No client code change required ✅ (already true; this is the architectural goal)
+
+---
+
+## 6. Related
+
+- `internal-devops/rfcs/0012-postgres-ha-via-cnpg.md` — the upstream RFC
+- `internal-devops/rfcs/0014-zero-touch-onboarding.md` — `runtime.databases[]` schema
+- `internal-devops/runbooks/postgres-failover-drill.md` — full platform runbook
+- `enclii.yaml` — Tezca's service declaration (will be updated post-RFC-0014)
+- `apps/indigo/settings.py` — connection settings (this PR)

--- a/docs/strategy/DOCKET_WATCHER_BOOTSTRAP_2026-04-27.md
+++ b/docs/strategy/DOCKET_WATCHER_BOOTSTRAP_2026-04-27.md
@@ -1,0 +1,234 @@
+# `madfam-org/docket-watcher` — Bootstrap Kit
+
+**Last Updated:** 2026-04-27
+**Track:** Track 7 of [FEATURE_PARITY_PLAN_2026-04-27](./FEATURE_PARITY_PLAN_2026-04-27.md) §3.7 (Path B).
+**Status:** Specification ready. Repo creation is operator-only (cannot spin up a sibling repo from inside Tezca). Scheduled Q1-2027 per the plan.
+
+---
+
+## 1. Why a sibling repo, not part of Tezca
+
+Per the plan §3.7, Path B was chosen over Path A (build inside Tezca):
+
+> Cleaner separation: Tezca = laws, docket-watcher = case files. Reuses Tezca's auth (Janua) + billing (Dhanam) + webhooks pattern. Could be onboarded via RFC 0014 zero-touch.
+
+Buho Legal owns the docket-monitoring market today (free tier monitors 5 cases, premium $749–$15,000 MXN/yr). MADFAM's parity offering is an ecosystem-aligned competitor: same cleaning + auth + billing patterns as the rest of the stack, plus tight integration with Tezca for "this docket activity references these laws."
+
+Building this **inside** `tezca-api` would contaminate the corpus product (different ToS, different scrape patterns, different fear-driven user workflow). Sibling repo is right.
+
+---
+
+## 2. Repo bootstrap checklist
+
+When the operator is ready to spin this up (per plan Q1-2027 sequencing):
+
+### 2.1 Create the repo
+
+```bash
+gh repo create madfam-org/docket-watcher --private --description "Mexican judicial docket monitoring (PJF + state TSJ). Sibling to madfam-org/tezca."
+```
+
+Initially **private** — same posture as Tezca was at PR #0. Flip to public when launch-ready.
+
+### 2.2 Onboard via RFC 0014 zero-touch flow
+
+Per `internal-devops/rfcs/0014-zero-touch-onboarding.md`, the operator runs:
+
+```bash
+enclii onboard --repo madfam-org/docket-watcher \
+  --db-name docket_watcher \
+  --secrets-file .env
+```
+
+This one-shot creates: namespace `docket-watcher`, ArgoCD app, Cloudflare tunnel routes, Janua client (`docket-watcher-web`), and NetworkPolicies.
+
+### 2.3 Domain provisioning
+
+Reserve via Porkbun + add to the canonical domain inventory in
+`internal-devops/ecosystem/domain-map.md`:
+
+| Subdomain | Backed by | Container port |
+|---|---|---|
+| `dockets.madfam.io` (or new TLD `dockets.lat`) | docket-watcher-web | 3000 |
+| `api.dockets.madfam.io` | docket-watcher-api | 8000 |
+| `admin.dockets.madfam.io` | docket-watcher-admin | 3001 |
+
+(Per ECOSYSTEM convention, new product domains get their own brand. `dockets.lat` matches the `tezca.mx` / `karafiel.mx` brand-per-product pattern.)
+
+---
+
+## 3. Architecture (target shape)
+
+```
+                  ┌──────────────────────────────────────┐
+                  │  docket-watcher-web (Next.js)        │
+                  │  - List my watched dockets            │
+                  │  - Add docket watch (case # / name)   │
+                  │  - Receive notifications              │
+                  │  - Cross-link to Tezca laws cited     │
+                  └──────────────────────────────────────┘
+                              │
+                              │ Janua JWT
+                              ▼
+                  ┌──────────────────────────────────────┐
+                  │  docket-watcher-api (Django, mirrors │
+                  │  tezca-api's Combined-Auth pattern)  │
+                  │                                      │
+                  │   Models:                            │
+                  │   - DocketWatch(case_number, name,   │
+                  │     court, user_id, alerts_enabled)  │
+                  │   - DocketEvent(watch_id, kind,      │
+                  │     occurred_at, raw_excerpt, ref_   │
+                  │     law_ids[])                       │
+                  │                                      │
+                  │   API:                               │
+                  │   POST /api/v1/watches/              │
+                  │   GET  /api/v1/watches/              │
+                  │   POST /api/v1/watches/test/         │
+                  │   POST /api/v1/webhooks/             │
+                  │     (HMAC-signed dispatch on event)  │
+                  └──────────────────────────────────────┘
+                              │
+                              │ Celery (poll daily/hourly)
+                              ▼
+            ┌──────────────────────────────────────────────┐
+            │  Scrapers (mirror apps/scraper/judicial/)    │
+            │   - PJF (Poder Judicial Federal)             │
+            │   - SCJN docket portal                       │
+            │   - Per-state TSJ (gradual rollout, mirrors  │
+            │     the state-laws scraper backlog)          │
+            └──────────────────────────────────────────────┘
+                              │
+                              │ enrichment: cross-link
+                              │ event excerpts to law_ids
+                              ▼
+            ┌──────────────────────────────────────────────┐
+            │  Tezca API consumer                          │
+            │   GET https://api.tezca.mx/api/v1/laws/?     │
+            │     name=<extracted_law_name>                │
+            │   (regular Institutional API key)            │
+            └──────────────────────────────────────────────┘
+```
+
+**Key constraints carried over from Tezca's architecture:**
+- Auth via Janua JWT + API keys (`dwk_*` prefix to disambiguate from `tzk_*`)
+- Billing via Dhanam (separate `docket_watcher_*` plan slugs)
+- Webhooks HMAC-signed, SSRF-protected (port `apps/api/utils/url_validation.py`)
+- Tier-throttled rate limits (port `apps/api/tier_throttles.py` minus the legal-corpus specifics)
+- Trilingual UI (es/en/nah) — same `LanguageContext` pattern
+
+**What's NEW for docket-watcher:**
+- Court-portal scrapers (PJF, SCJN dockets, state TSJs) — different from Tezca's gazette scrapers
+- Watch + event data model (transactional, vs Tezca's reference-data model)
+- Cross-linking to Tezca law references via `apps/api-client` SDK
+
+---
+
+## 4. Pricing recommendation
+
+Per the parity plan §3.7 and `internal-devops/decisions/2026-04-25-tulana-ecosystem-pricing.md` methodology, anchored on Buho Legal's bands:
+
+| Tier | MXN/mo | Includes | Notes |
+|---|---|---|---|
+| Free | $0 | 3 case watches, email alerts | Matches Buho free (5 cases) but drops to 3 to push paid conversion |
+| Personal | $199 | 25 case watches, email + push | Matches Tezca Community ($199) — same anchor for cross-product bundle |
+| Despacho | $599 | 200 case watches, name alerts, daily digest | Matches Tezca Essentials |
+| Firma | $1,999 | Unlimited watches, webhook fanout for Karafiel pattern, API access | Matches Tezca Institutional |
+
+Confidence: low. Run through Tulana v0.2 once the first 5 paying customers reveal price elasticity (mirrors Tezca's pricing-review trigger per plan §6.7).
+
+**Cross-product bundle opportunity:** Tezca + docket-watcher + Karafiel = "MADFAM Compliance Stack" — sell as a unified Institutional offering at $4,999 MXN/mo (vs $1,999 × 3 = $5,997 standalone).
+
+---
+
+## 5. Initial files for the repo (suggested)
+
+When the operator runs `gh repo create`, the first commit should establish the structure. Here's a starter layout that mirrors Tezca's conventions:
+
+```
+docket-watcher/
+├── apps/
+│   ├── api/                  # Django REST API (mirrors tezca/apps/api)
+│   ├── web/                  # Next.js public site
+│   ├── admin/                # Internal admin console
+│   ├── scraper/
+│   │   ├── pjf/              # Poder Judicial Federal scrapers
+│   │   ├── scjn_dockets/     # SCJN-specific docket portal
+│   │   └── state_tsj/        # Per-state TSJ scrapers (gradual)
+│   └── indigo/               # Django settings + WSGI (rename to project)
+├── packages/
+│   ├── lib/                  # @docket-watcher/lib
+│   ├── ui/                   # @docket-watcher/ui (or reuse @tezca/ui)
+│   └── api-client/           # @docket-watcher/api-client (published SDK)
+├── tests/
+├── enclii.yaml               # Onboarding spec (per RFC 0014)
+├── CLAUDE.md                 # Service-specific instructions
+├── docker-compose.yml
+└── pyproject.toml
+```
+
+Suggested initial CLAUDE.md skeleton (paste as the first file):
+
+```markdown
+# CLAUDE.md — docket-watcher Developer Guide
+
+## Project Overview
+
+Mexican judicial docket monitoring. Sibling to `madfam-org/tezca`.
+
+**Why separate from tezca**: Tezca tracks laws; docket-watcher tracks
+case files. Different scrape sources (court portals vs gazettes),
+different user workflows (litigators tracking active cases vs
+researchers reading laws), different ToS posture.
+
+**Cross-product integration**: docket-watcher consumes the public Tezca
+API to link event excerpts to law references.
+
+## Stack
+... (mirror tezca CLAUDE.md structure)
+```
+
+---
+
+## 6. Done criterion (Q1-2027 target)
+
+- [ ] Repo created (`madfam-org/docket-watcher`, private)
+- [ ] Onboarded via `enclii onboard` (per RFC 0014)
+- [ ] Domain provisioned (`dockets.madfam.io` or `dockets.lat`)
+- [ ] First scraper green (PJF federal, mirrors `tezca/apps/scraper/judicial/scjn_playwright.py`)
+- [ ] User can register a `DocketWatch`, receive an alert within 1 hour of court-portal update
+- [ ] Cross-linking: at least one event correctly links to a Tezca law via the public API
+- [ ] Pricing tiers in Dhanam catalog (`docket_watcher_free`, `docket_watcher_personal`, `docket_watcher_despacho`, `docket_watcher_firma`)
+- [ ] Public landing page at `dockets.madfam.io`
+
+---
+
+## 7. Risks (carried from the plan §9)
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Court portals aggressively rate-limit | High | Material | Polite scraping (1 req/min like Tezca's pattern); fallback to Wayback for backfill |
+| Buho Legal incumbent advantage | Medium | Material | Cross-product bundle pitch: docket-watcher + Tezca + Karafiel as one stack, undercut Buho's standalone pricing |
+| ToS prohibits scraping | Medium | Severe | Read each portal's ToS before scraper rollout. Some may require operator-mediated access (e.g., direct API agreement) |
+| Compliance with Mexican judiciary data-protection rules | High | Severe | Anonymize PII in cached event excerpts; consult legal before launch |
+
+---
+
+## 8. Why this doc lives in tezca
+
+The `tezca` repo is the natural home for the **specification** because:
+1. The competitive benchmark + parity plan + Karafiel-as-anchor-customer thesis live here
+2. Operators reading the FEATURE_PARITY_PLAN need a co-located bootstrap
+3. The doc itself doesn't ship code — pure spec until repo creation
+
+When the repo exists, this doc gets a "moved-to" pointer and the canonical source becomes `madfam-org/docket-watcher/docs/strategy/BOOTSTRAP.md`.
+
+---
+
+## 9. Related
+
+- [FEATURE_PARITY_PLAN_2026-04-27.md §3.7](./FEATURE_PARITY_PLAN_2026-04-27.md)
+- [COMPETITIVE_BENCHMARK_2026-04-27.md §2.1](./COMPETITIVE_BENCHMARK_2026-04-27.md) — Buho Legal profile
+- `internal-devops/rfcs/0014-zero-touch-onboarding.md`
+- `internal-devops/ecosystem/domain-map.md` — domain reservation pattern
+- `internal-devops/decisions/2026-04-25-tulana-ecosystem-pricing.md` — pricing methodology

--- a/enclii.yaml
+++ b/enclii.yaml
@@ -28,6 +28,15 @@ spec:
         description: Legal ops console
   runtime:
     port: 8000
+    # TODO (Track 6, post-RFC-0014): once Switchyard's
+    # runtime.databases[] schema is live, declare the CNPG dependency
+    # here so the cutover (DB_HOST flip) is a one-line change.
+    # See docs/strategy/CNPG_MIGRATION_PREP_2026-04-27.md §1.2.
+    #
+    # databases:
+    #   - name: tezca
+    #     cluster: postgres-ha
+    #     access: read-write
   domains:
     - name: api.tezca.mx
       environment: production


### PR DESCRIPTION
Combines Tracks 6 and 7 of FEATURE_PARITY_PLAN_2026-04-27. Both are prep for future-quarter execution and naturally co-ship.

## Track 6 — CNPG migration prep (§3.2)

**Code:** `apps/indigo/settings.py` adds CNPG-friendly Postgres connection knobs (connect_timeout=5, keepalives_*, CONN_MAX_AGE=0). All overridable via env. Survives RFC 0012's <60s primary-promotion window without a Django reload.

**enclii.yaml**: TODO comment for the `runtime.databases[]` declaration that lands when RFC 0014 schema is live.

**Doc**: `CNPG_MIGRATION_PREP_2026-04-27.md` with full prep + cutover runbook + rollback.

## Track 7 — docket-watcher bootstrap kit (§3.7 Path B)

**Pure spec:** `DOCKET_WATCHER_BOOTSTRAP_2026-04-27.md` for the operator to spin up `madfam-org/docket-watcher` when scheduled (Q1-2027). Includes architecture, repo layout, `enclii onboard` command, domain pattern, pricing tiers anchored on Buho Legal + Tezca tier ladder.

## Verification

- [x] `poetry run pytest tests/` — 1527 passed, 0 regressions from settings.py change
- [x] black + isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)