### PR TITLE
docs(comprehensive): post-session refresh covering all 8 shipped tracks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,13 @@ DB_PASSWORD=change-me
 DB_HOST=localhost
 DB_PORT=5432
 
+# Postgres connection knobs tuned for the CNPG cluster (per Track 6 of
+# docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md §3.2). Defaults are
+# safe for both single-instance and CNPG topologies.
+# DB_CONNECT_TIMEOUT=5         # seconds; fail-fast on dead primary
+# DB_KEEPALIVES_IDLE=30        # seconds; detect dropped conns < 60s
+# DB_CONN_MAX_AGE=0            # 0 = open/close per request (PgBouncer fronts)
+
 # ── Elasticsearch ─────────────────────────────────────────────────────
 ES_HOST=http://localhost:9200
 # Required when xpack.security.enabled=true (default in docker-compose.yml).
@@ -99,6 +106,10 @@ DHANAM_CHECKOUT_URL=https://dhanam.madfam.io/checkout
 # HMAC-SHA256 secret signing /api/v1/billing/webhook/. Required in any
 # environment where Dhanam delivers subscription events.
 DHANAM_WEBHOOK_SECRET=
+# Frontend-visible Dhanam API base. Used by /cuenta/billing to fetch the
+# customer-portal URL and the invoice list. Override only in
+# dev/staging when pointing at a non-prod Dhanam instance.
+NEXT_PUBLIC_DHANAM_API_URL=https://api.dhan.am
 
 # Trial durations (days). NO_CC = before user supplies a card; WITH_CC =
 # extended duration once Dhanam fires trial.cc_provided.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,16 @@ npm run dev:all                     # both concurrently
 | `NEXT_PUBLIC_MONETIZATION_ENABLED` | `false` | When `true`, enables full tier checkout flows. When `false` (default), shows interest-capture forms instead of paywalls |
 | `CRM_WEBHOOK_URL` | `""` | Phyne-CRM webhook URL (e.g. `https://crm.madfam.io/api/webhooks/tezca`). No-ops when empty |
 | `CRM_WEBHOOK_SECRET` | `""` | HMAC-SHA256 secret for CRM webhook signing. No-ops when empty |
+| `CHAT_ENABLED` | `false` | Master kill-switch for `/api/v1/chat/preguntar/`. Flip to `true` once Selva onboarding lands |
+| `CHAT_BACKEND` | `mock` | `mock` (deterministic, dev/test) or `selva` (production OpenAI-compatible /v1) |
+| `SELVA_API_URL` | `https://agents-api.madfam.io/v1` | Selva endpoint when `CHAT_BACKEND=selva`. Post-cutover: `https://api.selva.town/v1` |
+| `SELVA_API_TOKEN` | `""` | Janua-relayed bearer token for the `tezca-selva-relay` client |
+| `SELVA_DEFAULT_MODEL` | `claude-haiku-4-5` | Default LLM model for chat completions |
+| `ES_USERNAME` | `""` | Elasticsearch basic-auth user (required when `xpack.security.enabled=true`, default in compose) |
+| `ES_PASSWORD` | `""` | Elasticsearch basic-auth password — override `changeme-dev-only` for any non-throwaway env |
+| `DB_CONNECT_TIMEOUT` | `5` | Postgres connect timeout in seconds. Tighter than kernel default to fail-fast on dead primary during CNPG failover |
+| `DB_KEEPALIVES_IDLE` | `30` | TCP keepalive idle (seconds). Detect dropped conns within ~60s vs Linux default ~2h |
+| `DB_CONN_MAX_AGE` | `0` | Django `CONN_MAX_AGE`. 0 = open/close per request (PgBouncer fronts the cluster) |
 
 ---
 
@@ -85,7 +95,7 @@ npm run dev:all                     # both concurrently
 ### Testing
 
 ```bash
-# Backend (pytest + django, 1332 tests)
+# Backend (pytest + django, 1527 tests as of 2026-04-27)
 poetry run pytest tests/ -v
 poetry run pytest tests/parsers/test_parser_v2.py    # parser tests (100 tests)
 
@@ -93,7 +103,7 @@ poetry run pytest tests/parsers/test_parser_v2.py    # parser tests (100 tests)
 poetry run pytest -m spotcheck -v
 python manage.py spot_check --golden-set             # management command
 
-# Web (vitest, 684 tests across 78 files)
+# Web (vitest, 761 tests across 85 files as of 2026-04-27)
 cd apps/web && npx vitest run
 
 # Admin (vitest, 82 tests across 12 files)
@@ -120,6 +130,18 @@ python manage.py classify_law_domains --law-id cpeum         # single law
 # Cross-reference backfill
 python manage.py backfill_cross_references --all --dry-run   # preview
 python manage.py backfill_cross_references --all --batch-size 50  # backfill
+
+# RMF (Resolución Miscelánea Fiscal) — SAT regulatory feed for Karafiel
+python -m apps.scraper.federal.rmf_scraper --year 2026                # discover only
+python -m apps.scraper.federal.rmf_scraper --year 2026 --download      # discover + fetch PDFs
+python manage.py ingest_rmf --catalog data/rmf/catalog.json            # upsert into Law table
+python manage.py ingest_rmf --catalog data/rmf/catalog.json --dry-run  # preview
+
+# State scrapers (manual run via Celery dispatch — useful before flipping a Beat schedule)
+python manage.py shell -c "from apps.scraper.scheduling.tasks import run_state_scraper; print(run_state_scraper('hidalgo'))"
+# State keys registered: baja_california, durango, quintana_roo, guerrero,
+# nuevo_leon, cdmx, estado_de_mexico, michoacan, san_luis_potosi, zacatecas,
+# aguascalientes, hidalgo, morelos, yucatan (14 of 32; coverage 14/32 → 16/32 with Wave 1A)
 
 # DOF health verification
 python manage.py verify_dof_health                           # 7-day report
@@ -247,15 +269,40 @@ Consuming services configure themselves to connect to Tezca, not the other way a
 - CC extension: `trial.cc_provided` Dhanam webhook event extends trial to 21 days from start
 - Frontend: `TrialBadge` (countdown in Navbar), `ConversionBanner` (CTA for non-paid users), `/precios` pricing page
 
+### AI Chat (`/preguntar`)
+
+- `POST /api/v1/chat/preguntar/` — first-party RAG-over-corpus chat assistant (Track 2 of `docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md` §3.1).
+- Four gating layers in `apps/api/chat/views.py:preguntar`: (1) `CHAT_ENABLED` env, (2) authenticated user, (3) `RequireFeature.of("chat")` (essentials+ tier), (4) daily-message budget per `chat_messages_per_day` in `tiers.json` (essentials=30, academic=100, institutional=1000, madfam=-1).
+- Tezca holds **zero** OpenAI/Anthropic API keys. Every LLM call routes through Selva at `/v1` (OpenAI-compatible) per the MADFAM ECOSYSTEM convention. Configurable via `CHAT_BACKEND` (`mock` for dev/test, `selva` for production).
+- RAG pipeline: ES BM25 retrieval (top-5, 800-char snippets) → system prompt with `[law_id#article_id]` citation format → Selva chat-completion → cited response with `/leyes/{id}#article-{N}` links rendered via the existing `LinkifiedArticle` component.
+- Failure-tolerant: ES down → empty context, polite reply, no Selva call. Selva down → 502 to user, no budget burn.
+- Usage logged to `APIUsageLog` rows tagged `endpoint='chat.preguntar'`. Budget reset is UTC 00:00.
+- Operator unblocker (Track 8): Selva must provision the `tezca-selva-relay` Janua client. Spec at `docs/strategy/SELVA_ONBOARDING_TICKET_2026-04-27.md`.
+
+### RMF (Resolución Miscelánea Fiscal)
+
+- SAT-published annual fiscal resolution + quarterly modifications + ~31 annexes per year. Required by Karafiel's Wave-1 GTM compliance feed (Track 1 / `docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md` §3.6).
+- Scraper: `apps/scraper/federal/rmf_scraper.py` (`RmfScraper` class). Requests-first against `www.sat.gob.mx`, polite 1 req/sec rate-limit, classifies anchors into annual / modification / annex documents.
+- Celery task: `dataops.run_rmf_scraper` — scheduled `rmf-quarterly-scrape` (8th of Jan/Apr/Jul/Oct, 03:00). Offset from `dof-historical-quarterly` (1st of same months).
+- Ingest: `python manage.py ingest_rmf --catalog data/rmf/catalog.json` upserts Law + LawVersion with `category="resolución_miscelánea_fiscal"` and `domains=["fiscal"]`.
+- Karafiel's webhook subscription `domain_filter: ["fiscal"]` will receive `law.created` / `law.updated` events for these via the standard `apps/api/webhooks.py` dispatch — no Karafiel-specific code in tezca.
+
+### Billing UI (`/cuenta/billing`)
+
+- Customer-facing billing surface delegating to Dhanam (Track 4 / `docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md` §3.3).
+- Tezca holds **zero** Stripe keys. Tezca calls `api.dhan.am/v1/portal` and `api.dhan.am/v1/invoices`; Dhanam owns subscription state.
+- Two display modes: `MONETIZATION_ENABLED=false` → InterestGate fallback; `MONETIZATION_ENABLED=true` → current-plan card + customer-portal CTA + invoice history table (PDF + CFDI 4.0 XML download links).
+- Webhook flow handled by `apps/api/billing_stream_consumer.py` (Redis stream `madfam:billing-events`, consumer group `tezca-consumers`). `subscription.activated|cancelled` events map to `APIKey.tier` updates.
+
 ### Route Conventions
 
-- **API endpoints are English:** `/api/v1/laws/`, `/api/v1/search/`, `/api/v1/categories/`, `/api/v1/coverage/`, `/api/v1/contributions/`, `/api/v1/judicial/`, `/api/v1/trial/`, `/api/v1/billing/`, `/api/v1/user/apikeys/`
-- **Web routes are Spanish:** `/leyes/`, `/busqueda/`, `/comparar/`, `/categorias/`, `/estados/`, `/cobertura/`, `/contribuir/`, `/convocatoria/`, `/jurisprudencia/`, `/desarrolladores/`, `/grafo/`, `/precios/`, `/bienvenida/`, `/login/`, `/cuenta/apikeys/`
+- **API endpoints are English:** `/api/v1/laws/`, `/api/v1/search/`, `/api/v1/categories/`, `/api/v1/coverage/`, `/api/v1/contributions/`, `/api/v1/judicial/`, `/api/v1/trial/`, `/api/v1/billing/`, `/api/v1/chat/preguntar/`, `/api/v1/user/apikeys/`
+- **Web routes are Spanish:** `/leyes/`, `/busqueda/`, `/comparar/`, `/categorias/`, `/estados/`, `/cobertura/`, `/contribuir/`, `/convocatoria/`, `/jurisprudencia/`, `/desarrolladores/`, `/grafo/`, `/preguntar/` (chat UI, follow-up PR), `/precios/`, `/bienvenida/`, `/login/`, `/cuenta/apikeys/`, `/cuenta/billing/`
 - 301 redirects exist from old English web routes (`/laws/` -> `/leyes/`)
 
 ### Domain Taxonomy
 
-- `Law.category` stores document type: `ley`, `acuerdo`, `reglamento`, `decreto`, `codigo`, `constitucion`, etc.
+- `Law.category` stores document type: `ley`, `acuerdo`, `reglamento`, `decreto`, `codigo`, `constitucion`, `resolución_miscelánea_fiscal` (RMF), etc.
 - `Law.domains` (JSONField, list of strings) stores legal branch classification: `labor`, `fiscal`, `criminal`, `civil`, `commercial`, `administrative`, `constitutional`, `environmental`, `health`, `education`
 - A law can belong to multiple domains (e.g. `["labor", "administrative"]`)
 - `classify_law_domains` management command populates `domains` via keyword matching against `Law.name`
@@ -428,6 +475,18 @@ type Lang = 'es' | 'en' | 'nah';
 | `apps/api/management/commands/verify_dof_health.py` | DOF daily task health report (last N days, optional `--run-now`) |
 | `apps/scraper/state/guerrero.py` | Guerrero state congress scraper |
 | `apps/scraper/state/nuevo_leon.py` | Nuevo Leon state congress scraper |
+| `apps/scraper/state/aguascalientes.py` | Aguascalientes state congress scraper (Wave 1A — `congresoags.gob.mx`) |
+| `apps/scraper/state/hidalgo.py` | Hidalgo state congress scraper (Wave 1A — `congreso-hidalgo.gob.mx`) |
+| `apps/scraper/state/morelos.py` | Morelos state congress scraper (Wave 1A — `congresomorelos.gob.mx`) |
+| `apps/scraper/state/yucatan.py` | Yucatán state congress scraper (Wave 1A — `congresoyucatan.gob.mx`) |
+| `apps/scraper/federal/rmf_scraper.py` | SAT Resolución Miscelánea Fiscal scraper (annual + quarterly mods + annexes; tags `domains=["fiscal"]` for Karafiel webhook fanout) |
+| `apps/api/management/commands/ingest_rmf.py` | Upserts RMF catalog into `Law` + `LawVersion` (sister to `ingest_non_legislative_laws`) |
+| `apps/api/chat/__init__.py` | First-party AI assistant package — exports `SelvaClient`, `MockSelvaClient`, `get_selva_client()` |
+| `apps/api/chat/selva_client.py` | OpenAI-compatible HTTP client + mock; selected via `CHAT_BACKEND` env. Tezca holds zero LLM API keys |
+| `apps/api/chat/retriever.py` | RAG retrieval over articles ES index; builds system prompt with `[law_id#article_id]` citation format |
+| `apps/api/chat/views.py` | `POST /api/v1/chat/preguntar/` view with 4 gating layers (CHAT_ENABLED → auth → RequireFeature("chat") → daily budget) |
+| `apps/api/billing_stream_consumer.py` | Redis Streams consumer for `madfam:billing-events` (subscription.activated|cancelled → APIKey.tier) |
+| `apps/web/app/cuenta/billing/page.tsx` | Customer-facing billing page — Dhanam-delegated portal CTA + invoice history (PDF + CFDI). Two modes via `MONETIZATION_ENABLED` |
 | `packages/mcp-server/main.py` | MCP server entry point (FastMCP + uvicorn) |
 | `packages/mcp-server/tools/` | 16 MCP tools proxying REST API |
 | `apps/api/es_index_manager.py` | ES alias management (zero-downtime reindex) |
@@ -510,14 +569,38 @@ type Lang = 'es' | 'en' | 'nah';
 - WeasyPrint and other optional deps are similarly skipped in CI
 - Docker Compose services have resource limits (cpu/memory) to prevent runaway containers
 
+## Strategy Documentation
+
+`docs/strategy/` is the authoritative home for product/architectural strategy. Read these before assuming a feature priority. Index: [`docs/strategy/INDEX.md`](docs/strategy/INDEX.md).
+
+| Doc | Purpose |
+|---|---|
+| `STRATEGIC_OVERVIEW.md` | High-level product vision (legacy, refresh pending) |
+| `PRD.md` | Product requirements (legacy, refresh pending) |
+| `COMPETITIVE_BENCHMARK_2026-04-27.md` | Tezca vs Buho/vLex/Tirant/Lexius/Help-AI gap analysis |
+| `FEATURE_PARITY_PLAN_2026-04-27.md` | Gap-by-gap implementation plan, ecosystem-anchored. Source-of-truth for which tracks are in flight |
+| `KARAFIEL_INTEGRATION_AUDIT_2026-04-27.md` | Tezca-side readiness for Karafiel as anchor paying customer; P0 SQL queries for operator |
+| `SELVA_ONBOARDING_TICKET_2026-04-27.md` | Operator-side spec for provisioning the Selva relay client (unblocks `CHAT_BACKEND=selva`) |
+| `CNPG_MIGRATION_PREP_2026-04-27.md` | Tezca-side connection-pool prep + cutover runbook (gated on RFC 0012 cluster) |
+| `DOCKET_WATCHER_BOOTSTRAP_2026-04-27.md` | Bootstrap kit for the `madfam-org/docket-watcher` sibling repo (Q1-2027) |
+| `partnerships/` | Partner-specific integration agreements |
+
+**Tracks shipped 2026-04-27 (PRs #46–52):** RMF scraper, `/preguntar` chat scaffold, state scrapers Wave 1A (4 states), `/cuenta/billing` scaffold, Karafiel audit doc, CNPG settings prep, docket-watcher spec, Selva onboarding ticket spec.
+
 ## Known Issues
 
 See `/Users/aldoruizluna/labspace/claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md` for the original ecosystem audit.
 
 Open:
 - **🟠 H7: TLS verification disabled on government scrapers** — `apps/scraper/http.py:79`, `federal/nom_scraper.py:273`, `municipal/pnt_scraper.py:604`. MITM risk — attacker can forge compliance evidence flowing into Karafiel. Pin CA bundles; if gov sites use old certs, narrow `verify=False` to specific hostnames with cert-fingerprint pinning.
+- **🟡 State coverage incomplete** — 16 of 32 states have scrapers (Wave 1A added Aguascalientes, Hidalgo, Morelos, Yucatán). Wave 1B/1C remaining for full parity claim per `FEATURE_PARITY_PLAN_2026-04-27.md` §3.5.
+- **🟡 ES single-node** — Postgres HA prep done (Track 6); ES HA is a separate pending project.
+- **🟡 First-paid-customer blockers** — Selva onboarding (CHAT_BACKEND flip), Stripe live keys + Tezca price IDs in Dhanam (MONETIZATION_ENABLED flip), and Karafiel team's Wave 1 Month 1 deliverables. All operator-side; specs are landed.
 
 Resolved:
 - ~~**🟠 H2: CORS echoes `*` when `Origin` header missing on API-key preflight**~~ — Fixed 2026-04-23 (#37, #40): missing Origin now 403s, allowed Origins echo back with `Vary: Origin`.
 - ~~**🟡 M3: `DEBUG=True` in `.env`**~~ — Resolved 2026-04-27: `.env` is not tracked and not present in repo; `.env.example` ships `DEBUG=False`. No prod workload risk from this vector.
 - ~~**🟡 H13: `.env` committed**~~ — Resolved: `.gitignore` covers `.env`, `.env.local`, `.env.*.local`, `.env.production`. Verified absent from `git ls-files`.
+- ~~**🟡 RMF scraper stub deleted with no replacement**~~ — Resolved 2026-04-27 (#46): full RMF scraper + ingest command + Celery beat schedule. SAT regulatory feed available for Karafiel's compliance use case.
+- ~~**🟡 No first-party AI assistant**~~ — Resolved 2026-04-27 (#47, #49): `/api/v1/chat/preguntar/` scaffold ships behind `CHAT_ENABLED=false`. Selva onboarding ticket spec landed; flip is one env-var change once Selva provisions `tezca-selva-relay`.
+- ~~**🟡 No subscription billing UI**~~ — Resolved 2026-04-27 (#51): `/cuenta/billing` scaffold ships behind `MONETIZATION_ENABLED=false`. Tezca delegates to Dhanam — zero Stripe keys held.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,11 @@
 # Leyes Como Código - Product Roadmap
 
-**Last Updated**: 2026-03-20
+**Last Updated**: 2026-04-27
 **Current Status**: 35,277 laws, 3.5M+ ES articles, 33,380+ cross-references
 **Data Motor**: Pipeline fix complete (state/municipal AKN parsing + unified indexer)
 **DataOps**: Protocol implemented (gap tracking, health monitoring, coverage dashboard)
 **Codebase Audit**: Full audit completed 2026-03-20 — see [Codebase Audit](#codebase-audit-2026-03-20) section
+**Strategy Layer**: Feature-parity plan landed 2026-04-27 — see [`docs/strategy/INDEX.md`](docs/strategy/INDEX.md) for the canonical source of "what's in flight." Tracks 1–8 (PRs #46–52) shipped same day.
 
 ---
 
@@ -14,7 +15,7 @@
 
 ---
 
-## Current Status (Mar 2026)
+## Current Status (Apr 2026)
 
 ### ✅ Achievements
 - **35,277 laws** in database (1,931 federal + 30,907 state + 2,439 municipal)
@@ -22,17 +23,23 @@
 - **98.9% parser accuracy** (world-class quality)
 - **3.5M+ articles** indexed in Elasticsearch
 - **Production-ready** backend infrastructure (K8s, HPA, cosign-signed images)
-- **Full-stack Testing** (1,234 backend + 643 web Vitest + 72 admin Vitest + 89 E2E + 18 MCP)
+- **Full-stack Testing** (**1,527** backend + **761** web Vitest + 82 admin Vitest + 89 E2E + 18 MCP — as of 2026-04-27)
 - **6-tier access control** with billing (Dhanam), trials, webhooks, API keys
 - **16-tool MCP server** published to PyPI for AI agent consumption
-- **20 Celery Beat tasks** automating scraping, pipeline, health checks, trials
+- **24+ Celery Beat tasks** including new `rmf-quarterly-scrape` (Track 1)
 - **Graph visualization** (Sigma.js, ego graph, global overview, public showcase)
 - **Judicial corpus** (SCJN jurisprudencia + tesis aisladas via API + Playwright scrapers)
+- **First-party AI assistant** scaffold (`/api/v1/chat/preguntar/`, Selva-routed, gated by `CHAT_ENABLED=false` until Selva onboarding lands)
+- **SAT regulatory feed** (`apps/scraper/federal/rmf_scraper.py`) — annual RMF + quarterly modifications + annexes; Karafiel-ready
+- **Customer billing UI** scaffold (`/cuenta/billing`) — Dhanam-delegated, gated by `MONETIZATION_ENABLED=false`
+- **State coverage** at 16/32 (Wave 1A added Aguascalientes, Hidalgo, Morelos, Yucatán)
 
 ### 🔄 In Progress
-- Tezca production deployment (infrastructure code done, manual provisioning remaining)
+- Operator unblockers: Stripe live keys, Selva onboarding, classify_law_domains backfill verification
+- Wave 1B state scrapers (8 medium-complexity states → 16/32 to 24/32)
+- `/preguntar` chat UI (frontend follow-up; backend ready)
 - Municipal pilot planning (Tier 1: 6 major cities)
-- State scraper expansion (~12 of 32 states have dedicated scrapers)
+- Karafiel integration runtime test (joint with Karafiel team)
 
 ---
 
@@ -257,6 +264,57 @@
 - ✅ Dynamic OG images per law (Next.js ImageResponse)
 - ✅ Homepage refresh: FeaturedLaws, QuickLinks, trilingual headings
 - ✅ About page (/acerca-de) with data sources, methodology, contact
+
+---
+
+## Completed Sprint: Q3-2026 Feature Parity (Tracks 1–8, 2026-04-27) ✅
+
+**Sprint Goal**: Close the parity gaps identified in the 2026-04-27 competitive benchmark by leveraging MADFAM ecosystem primitives (Selva, Dhanam, CNPG, Karafiel-as-customer) instead of building greenfield. Source-of-truth: [`docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md`](docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md).
+
+### Shipped (8 PRs, single session — #46 through #52)
+
+| Track | PR | Deliverable |
+|---|---|---|
+| 1 — RMF recovery | #46 | SAT scraper + ingest command + quarterly Celery beat + 20 tests. Karafiel's compliance feed unblocked. |
+| 2 — `/preguntar` chat | #47 | Selva-routed RAG-over-corpus chat at `/api/v1/chat/preguntar/`. Four gating layers, mockable client, 19 tests. |
+| 3 — State scrapers Wave 1A | #50 | Aguascalientes, Hidalgo, Morelos, Yucatán. Coverage 12/32 → 16/32. 45 parametrized tests. |
+| 4 — Billing UI | #51 | `/cuenta/billing` with Dhanam-delegated portal + invoice history. 11 tests. Tezca holds zero Stripe keys. |
+| 5 — Karafiel integration audit | #48 | Tezca-side readiness verified. P0: domain-classification ≥95% before Karafiel goes live (operator SQL queries provided). |
+| 6 — CNPG migration prep | #52 | Postgres connection-pool knobs (connect_timeout, keepalives, CONN_MAX_AGE). Cutover runbook. Gated on RFC 0012. |
+| 7 — docket-watcher bootstrap | #52 | Spec for `madfam-org/docket-watcher` sibling repo (Q1-2027 scheduled). Architecture, layout, pricing tiers. |
+| 8 — Selva onboarding ticket | #49 | Operator-side spec for `tezca-selva-relay` Janua client. Unblocks `CHAT_BACKEND=selva` flip. |
+
+### Strategic outcome
+
+Tezca closes every "missing-vs-competitors" capability while preserving every "unique-to-Tezca" moat (MCP, public API at low tiers, A-F quality grading, AGPL self-hosting, cross-reference graph, trilingual UI). The remaining work is operator-only: Stripe credentialing, Selva provisioning, Karafiel timeline, RFC 0012 cluster shipping.
+
+### Cross-references
+- [`docs/strategy/INDEX.md`](docs/strategy/INDEX.md) — strategy doc index
+- [`docs/strategy/COMPETITIVE_BENCHMARK_2026-04-27.md`](docs/strategy/COMPETITIVE_BENCHMARK_2026-04-27.md) — gap analysis
+- [`docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md`](docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md) — track-by-track plan
+
+---
+
+## Next Sprint: Wave 1B — State Coverage 16/32 → 24/32
+
+**Sprint Goal**: Continue closing the state-scraper gap. 8 medium-complexity states (HTML + JS-rendered, no WAFs).
+
+### Targets (suggested)
+
+| State | Portal | Complexity |
+|---|---|---|
+| Coahuila | congresocoahuila.gob.mx | Medium |
+| Guanajuato | congresogto.gob.mx | Medium |
+| Jalisco | congresojal.gob.mx | Medium |
+| Puebla | congresopuebla.gob.mx | Medium |
+| Sinaloa | congresosinaloa.gob.mx | Medium |
+| Sonora | congresoson.gob.mx | Medium |
+| Tamaulipas | congresotamaulipas.gob.mx | Medium |
+| Veracruz | legisver.gob.mx | Medium |
+
+Each state follows the existing `apps/scraper/state/baja_california.py` template + Wave 1A extension. Add to `run_state_scraper` dispatch table; flip Beat schedules per-state after first manual green run.
+
+**Wave 1C** (Q1-2027 scheduled): 8 hostile states needing Playwright/madfam-crawler delegation.
 
 ---
 

--- a/docs/strategy/INDEX.md
+++ b/docs/strategy/INDEX.md
@@ -1,0 +1,85 @@
+# Strategy Documentation Index
+
+**Last Updated:** 2026-04-27
+
+This directory holds Tezca's product/architectural strategy. If you're new to the project and need to know "why X" or "what should we build next," start here. The documents are listed in suggested reading order.
+
+---
+
+## Reading order for new contributors
+
+1. **[STRATEGIC_OVERVIEW.md](./STRATEGIC_OVERVIEW.md)** — High-level product vision. Legacy doc; partial refresh pending in 2026-Q3.
+2. **[PRD.md](./PRD.md)** — Product requirements. Legacy; partial refresh pending.
+3. **[COMPETITIVE_BENCHMARK_2026-04-27.md](./COMPETITIVE_BENCHMARK_2026-04-27.md)** — Where Tezca sits against vLex, Tirant Prime, Lexius, Help-AI, Buho Legal. Resulting positioning: "the open infrastructure for Mexican law — the data layer everyone builds on top of."
+4. **[FEATURE_PARITY_PLAN_2026-04-27.md](./FEATURE_PARITY_PLAN_2026-04-27.md)** — **Source-of-truth** for what's in flight. Maps each competitive gap to the responsible MADFAM ecosystem service (Selva, Dhanam, CNPG, Karafiel, Tulana, Coforma). 13 sections, 8 quarters of sequencing, 8 open operator decisions.
+
+## Track-specific docs (FEATURE_PARITY_PLAN cross-references)
+
+5. **[KARAFIEL_INTEGRATION_AUDIT_2026-04-27.md](./KARAFIEL_INTEGRATION_AUDIT_2026-04-27.md)** — Track 5. Tezca-side readiness for Karafiel as anchor paying customer. Includes operator-runnable SQL queries to verify domain-classification coverage (P0 before Karafiel goes live).
+6. **[SELVA_ONBOARDING_TICKET_2026-04-27.md](./SELVA_ONBOARDING_TICKET_2026-04-27.md)** — Track 8. Operator-side spec for provisioning the `tezca-selva-relay` Janua client. Unblocks `CHAT_BACKEND=selva` flip in production.
+7. **[CNPG_MIGRATION_PREP_2026-04-27.md](./CNPG_MIGRATION_PREP_2026-04-27.md)** — Track 6. Tezca-side connection-pool knobs (already shipped) plus the cutover runbook. Gated on RFC 0012 (`madfam-org/enclii`) shipping the cluster.
+8. **[DOCKET_WATCHER_BOOTSTRAP_2026-04-27.md](./DOCKET_WATCHER_BOOTSTRAP_2026-04-27.md)** — Track 7. Bootstrap kit for the `madfam-org/docket-watcher` sibling repo (Q1-2027). Architecture, repo layout, RFC 0014 onboarding command, pricing tiers anchored on Buho Legal.
+
+## Subdirectories
+
+- **[partnerships/](./partnerships/)** — Partner-specific integration agreements (legal-ops, MADFAM ecosystem, etc.)
+
+---
+
+## Status snapshot (as of 2026-04-27)
+
+### What landed in PRs #46–52 this session
+
+| Track | PR | Type | Done? |
+|---|---|---|---|
+| Track 1: §3.6 RMF scraper | #46 | code+tests | ✅ |
+| Track 2: §3.1 `/preguntar` chat scaffold | #47 | code+tests, gated | ✅ scaffold; awaits Track 8 |
+| Track 5: §3.4 Karafiel audit | #48 | docs | ✅ Tezca-side; awaits operator + Karafiel team |
+| Track 8: Selva onboarding ticket | #49 | docs | ✅ spec; awaits operator |
+| Track 3: §3.5 State scrapers Wave 1A | #50 | code+tests | ✅ 4 states; coverage 12→16 |
+| Track 4: §3.3 Billing UI scaffold | #51 | code+tests, gated | ✅ scaffold; awaits operator |
+| Track 6: §3.2 CNPG migration prep | #52 | code+docs | ✅ Tezca-side; awaits RFC 0012 |
+| Track 7: §3.7 docket-watcher bootstrap | #52 | docs | ✅ spec; Q1-2027 |
+
+### Operator-only blockers
+
+These cannot be done by an agent — listed in priority order for revenue impact:
+
+1. Stripe live keys + Stripe-MX live keys provisioned in Dhanam → flips `MONETIZATION_ENABLED=true`
+2. Stripe price IDs created (`tezca_community`, `tezca_essentials`, `tezca_institutional`)
+3. Selva provisions `tezca-selva-relay` Janua client → flips `CHAT_BACKEND=selva`
+4. Run `classify_law_domains --all --force` on production (verifies ≥95% Karafiel webhook readiness)
+5. Karafiel team's Wave 1 Month 1 deliverables (their database live + e.firma uploaded)
+6. PMF score crosses activation OR operator-override for known-buyer scenarios
+7. CNPG cluster shipping in `madfam-org/enclii` (RFC 0012)
+8. `gh repo create madfam-org/docket-watcher` + `enclii onboard` (Q1-2027)
+
+### What's still pending an agent (i.e., Tezca-side engineering work)
+
+- **Wave 1B state scrapers** — 8 medium-complexity states (Coahuila, Guanajuato, Jalisco, Puebla, Sonora, Tamaulipas, Veracruz, Sinaloa). 16/32 → 24/32 progression.
+- **Wave 1C state scrapers** — 8 hostile states needing Playwright/madfam-crawler delegation.
+- **`/preguntar` chat UI** — backend ready in #47; frontend `apps/web/app/preguntar/page.tsx` is a follow-up PR.
+- **Coverage dashboard tile flip per state** — manual per-state validation post-deploy.
+- **Public quality dashboard** — A-F grade distribution + last-update-timestamps publicized for the moat.
+- **ES HA project** — sister of RFC 0012; not yet planned.
+- **ROADMAP.md refresh** — last touched 2026-03-20; Q3-2026 → Q1-2027 priorities now in the parity plan need to land in ROADMAP.md too.
+
+---
+
+## Naming convention
+
+- **Strategy docs** with date suffix `_YYYY-MM-DD.md` are point-in-time briefings. They don't get edited in place — superseded versions are added with new dates.
+- **Strategy docs without a date suffix** (`STRATEGIC_OVERVIEW.md`, `PRD.md`) are living documents that are revised in place.
+- This index (`INDEX.md`) is updated whenever a new strategy doc lands.
+
+When in doubt: write a new dated doc rather than edit an old one. Cheap to add, free to ignore.
+
+---
+
+## Related (outside `docs/strategy/`)
+
+- `CLAUDE.md` (repo root) — developer guide. Cross-references this directory.
+- `ROADMAP.md` (repo root) — engineering execution roadmap. Strategy docs feed into roadmap items.
+- `internal-devops/ECOSYSTEM.md` — MADFAM-wide ecosystem map. Strategy docs lean on its constraint contracts (Selva owns inference, Dhanam owns money, etc.).
+- `internal-devops/ecosystem/gtm-strategy.md` — GTM master plan; defines Karafiel as Tezca's anchor customer.
+- `internal-devops/decisions/2026-04-25-tulana-ecosystem-pricing.md` — pricing source-of-truth.


### PR DESCRIPTION
Refreshes the project's reference docs after the 2026-04-27 feature-parity session that landed 8 tracks (PRs #46–#52). **No code changes.**

## What's updated

- **CLAUDE.md** — test counts (1527 backend / 761 web), env-var table extended (chat, Selva, ES auth, CNPG knobs), new Architecture sections (AI Chat, RMF, Billing UI), Key Files table (+12 entries), new Strategy Documentation section, Known Issues split into Open/Resolved.
- **ROADMAP.md** — Last Updated bumped, Achievements/In Progress reflect reality, new "Completed Sprint: Q3-2026 Feature Parity" section summarizing all 8 tracks, new "Next Sprint: Wave 1B" section.
- **docs/strategy/INDEX.md** (NEW) — reading order, track→PR map, operator-only blockers, pending agent work, naming convention.
- **.env.example** — CNPG connection knobs + NEXT_PUBLIC_DHANAM_API_URL added.

## Verification (all green)

- [x] `poetry run pytest tests/` — **1527 passed**, 15 skipped, 0 failures
- [x] `cd apps/web && npx vitest run` — **761 passed** across 85 files
- [x] `poetry run black --check apps/ tests/ scripts/` — clean
- [x] `poetry run isort --check-only apps/ tests/ scripts/` — clean
- [x] `npm run lint:web` — clean
- [x] tiers.json parseable, 8 tiers validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)