### PR TITLE
chore(security): enforce silent-except CI gate + add TLS fingerprint pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
     - name: Check File Sizes
       run: poetry run python scripts/utils/audit_file_sizes.py
 
+    - name: Audit silent bare-except blocks
+      # Fails CI on any new `except Exception: pass`-style swallow without
+      # `# noqa: BLE001`. See scripts/utils/audit_silent_excepts.py.
+      run: poetry run python scripts/utils/audit_silent_excepts.py
+
     - name: Run Pytest with coverage
       run: poetry run pytest tests/ -v --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=44
       env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -592,7 +592,7 @@ type Lang = 'es' | 'en' | 'nah';
 See `/Users/aldoruizluna/labspace/claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md` for the original ecosystem audit.
 
 Open:
-- **🟠 H7: TLS verification disabled on government scrapers** — `apps/scraper/http.py:79`, `federal/nom_scraper.py:273`, `municipal/pnt_scraper.py:604`. MITM risk — attacker can forge compliance evidence flowing into Karafiel. Pin CA bundles; if gov sites use old certs, narrow `verify=False` to specific hostnames with cert-fingerprint pinning.
+- **🟡 H7 (architecture fix landed; capture sweep pending)** — `apps/scraper/http.py` now supports per-host SHA-256 fingerprint pinning via `HOST_FINGERPRINTS` and a `_FingerprintPinnedAdapter`. The 10 hosts still in `INSECURE_HOSTS` need fingerprint capture (`scripts/utils/capture_tls_fingerprint.py <host>`) before the residual MITM window closes. Operator task: schedule a capture sweep on stable network.
 - **🟡 State coverage incomplete** — 16 of 32 states have scrapers (Wave 1A added Aguascalientes, Hidalgo, Morelos, Yucatán). Wave 1B/1C remaining for full parity claim per `FEATURE_PARITY_PLAN_2026-04-27.md` §3.5.
 - **🟡 ES single-node** — Postgres HA prep done (Track 6); ES HA is a separate pending project.
 - **🟡 First-paid-customer blockers** — Selva onboarding (CHAT_BACKEND flip), Stripe live keys + Tezca price IDs in Dhanam (MONETIZATION_ENABLED flip), and Karafiel team's Wave 1 Month 1 deliverables. All operator-side; specs are landed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,11 +47,16 @@ We commit to the following service level objective on dependency vulnerabilities
 
 ### TLS verification on government scrapers
 
-Some Mexican government portals ship expired or misconfigured TLS chains. The allowlist of hosts where `verify=False` is acceptable lives in `apps/scraper/http.py:INSECURE_HOSTS`. Adding a host requires:
+Some Mexican government portals ship expired or misconfigured TLS chains. `apps/scraper/http.py` resolves trust through two layers:
 
-1. Documented justification (cert chain inspection, last-renewal date)
-2. Per-host fingerprint pinning where feasible (Workstream 7 of the A+ plan tightens this from blanket bypass to fingerprint pinning)
-3. Annual review of the allowlist — hosts that have since fixed their cert chains get removed
+1. **`HOST_FINGERPRINTS`** — preferred. The host's leaf cert SHA-256 is compared against a pinned value at connection time. A mismatch fails the connection (no fallback). Pinning a host requires capturing the fingerprint with `scripts/utils/capture_tls_fingerprint.py <host>`. Pinned hosts are reviewed annually or whenever a connection is rejected.
+
+2. **`INSECURE_HOSTS`** — fallback for chains too unstable to pin (e.g. multi-balancer rotations). Adding a host requires:
+   - Documented justification (cert chain inspection, last-renewal date)
+   - A capture attempt — if the leaf is stable, fingerprint instead
+   - Annual review — hosts that fix their chains are removed
+
+Hosts not in either set get normal CA-verified TLS. Test coverage in `tests/scraper/test_http.py` exercises both trust paths.
 
 ## Supported Versions
 

--- a/apps/api/admin_views.py
+++ b/apps/api/admin_views.py
@@ -260,7 +260,7 @@ def list_jobs(request):
                 )
         except (
             Exception
-        ):  # noqa: broad-except — import may fail if dataops app is not installed
+        ):  # noqa: BLE001 — dataops app may not be installed; absence is fine here
             pass
 
         # Always include current ingestion status as first entry if no logs

--- a/apps/api/ingestion_manager.py
+++ b/apps/api/ingestion_manager.py
@@ -79,7 +79,7 @@ class IngestionManager:
             return True, f"Ingestion started (task {result.id})"
         except (
             Exception
-        ):  # noqa: broad-except — Celery/Redis may be unavailable, fall back to thread
+        ):  # noqa: BLE001 — Celery/Redis may be unavailable, fall back to thread
             pass
 
         # Fallback: thread-based execution

--- a/apps/api/management/commands/index_laws.py
+++ b/apps/api/management/commands/index_laws.py
@@ -10,6 +10,7 @@ Usage:
     python manage.py index_laws --all --tier state
 """
 
+import logging
 import re
 
 from django.core.management.base import BaseCommand
@@ -24,6 +25,8 @@ from apps.api.es_index_manager import (
 )
 from apps.api.models import Law
 from apps.api.utils.paths import ES_HOST, read_data_content
+
+logger = logging.getLogger(__name__)
 
 INDEX_LAWS = "laws"
 INDEX_ARTICLES = "articles"
@@ -491,7 +494,11 @@ class Command(BaseCommand):
                         art["text"]
                     )
                 except Exception:
-                    pass  # Skip embedding on failure, article is still indexed
+                    logger.debug(
+                        "Embedding generation failed for article in %s; indexing without it",
+                        law.official_id,
+                        exc_info=True,
+                    )
 
             actions.append(doc)
 
@@ -647,8 +654,12 @@ class Command(BaseCommand):
                             f"Use --include-quarantined to override."
                         )
                     )
-            except Exception:
-                pass  # Skip quarantine filtering if DB schema not migrated yet
+            except (
+                Exception
+            ):  # noqa: BLE001 — pre-migration schemas may lack quality_grade column
+                logger.debug(
+                    "quarantine filter skipped (DB schema not migrated)", exc_info=True
+                )
 
         if options.get("limit"):
             laws = laws[: options["limit"]]

--- a/apps/api/tasks.py
+++ b/apps/api/tasks.py
@@ -562,9 +562,7 @@ def _finish_acquisition_log(log_entry, succeeded, failed, total):
         log_entry.failed = failed
         log_entry.ingested = succeeded
         log_entry.finish(error_summary=error_summary)
-    except (
-        Exception
-    ):  # noqa: broad-except — best-effort logging, must not break pipeline
+    except Exception:  # noqa: BLE001 — best-effort logging, must not break pipeline
         pass
 
 

--- a/apps/parsers/pipeline.py
+++ b/apps/parsers/pipeline.py
@@ -4,6 +4,7 @@ Law ingestion pipeline - End-to-end processing.
 Combines: Download → Extract → Parse → Validate → Quality Assessment
 """
 
+import logging
 import subprocess
 
 # Import components
@@ -20,6 +21,8 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from apps.parsers.error_tracker import ErrorTracker
+
+logger = logging.getLogger(__name__)
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -266,8 +269,12 @@ class IngestionPipeline:
                                 pdf_path,
                                 quality_metrics=metrics,
                             )
-                        except Exception:
-                            pass  # Best-effort DB save for quarantined
+                        except (
+                            Exception
+                        ):  # noqa: BLE001 — best-effort save for quarantined laws
+                            logger.debug(
+                                "DB save failed for quarantined law", exc_info=True
+                            )
                     return result
 
                 # Stage 5: Detect cross-references

--- a/apps/parsers/state_parser.py
+++ b/apps/parsers/state_parser.py
@@ -246,9 +246,8 @@ class StateLawParser:
                     parser_confidence=parse_result.confidence,
                 )
                 result.quality_metrics = quality
-            except Exception as e:
-                # Quality calc failure is non-fatal
-                pass
+            except Exception:  # noqa: BLE001 — quality calc failure is non-fatal
+                logger.debug("quality calc failed for %s", slug, exc_info=True)
 
             # 5. Cross-references (optional, non-fatal)
             try:

--- a/apps/scraper/http.py
+++ b/apps/scraper/http.py
@@ -1,10 +1,24 @@
 """
-Centralized SSL-bypass session factory for government websites.
+Centralized SSL session factory for government websites.
 
 Many Mexican government portals have expired or misconfigured SSL certificates.
-This module provides a single place to manage SSL bypass decisions, keeping an
-explicit allowlist of known-problematic hosts instead of scattering
-``verify=False`` throughout the codebase.
+This module manages two layers of trust:
+
+1. **Fingerprint-pinned hosts** (preferred): the host's leaf certificate is
+   compared against a known SHA-256 fingerprint. Even if a CA chain would
+   reject the cert, an exact-match fingerprint is treated as authoritative.
+   See ``HOST_FINGERPRINTS`` for the pinned hosts and audit dates.
+
+2. **Insecure-allowlisted hosts** (fallback): hosts in ``INSECURE_HOSTS`` get
+   ``verify=False`` because their chains are too unstable to pin. Adding to
+   this set requires documented justification (see SECURITY.md §"TLS
+   verification on government scrapers").
+
+Hosts not in either set get normal CA-verified TLS.
+
+Capture a new fingerprint with::
+
+    poetry run python scripts/utils/capture_tls_fingerprint.py <hostname>
 
 Usage::
 
@@ -14,18 +28,42 @@ Usage::
     resp = session.get("https://dof.gob.mx/some/path")
 """
 
+from __future__ import annotations
+
+import hashlib
 import logging
+import socket
+import ssl
 from urllib.parse import urlparse
 
 import requests
 import urllib3
+from requests.adapters import HTTPAdapter
+from urllib3.poolmanager import PoolManager
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Allowlist of government hosts with known SSL issues.
-# Only these hosts will have certificate verification disabled.
+# Fingerprint-pinned hosts: leaf cert SHA-256 (uppercase hex, colon-separated)
 # ---------------------------------------------------------------------------
+# When a host is here, the leaf certificate is fetched at connection time and
+# compared against the known fingerprint. A match is authoritative even if the
+# CA chain is broken; a mismatch fails the connection (no fallback). Capture
+# new fingerprints with `scripts/utils/capture_tls_fingerprint.py`.
+#
+# Format: { hostname: (sha256_hex, captured_iso_date, captured_by_url) }
+# Review cadence: annually, or whenever a connection failure is reported.
+
+HOST_FINGERPRINTS: dict[str, tuple[str, str, str]] = {
+    # No hosts pinned yet — populated as fingerprints are captured.
+    # First capture sweep is tracked in SECURITY.md §"TLS verification".
+}
+
+# ---------------------------------------------------------------------------
+# Allowlist of government hosts with known SSL issues (no pinning available)
+# ---------------------------------------------------------------------------
+# Only these hosts have certificate verification disabled. Adding to this set
+# requires documented justification — see SECURITY.md.
 
 INSECURE_HOSTS: frozenset[str] = frozenset(
     {
@@ -58,29 +96,93 @@ DEFAULT_TIMEOUT = 30  # seconds
 
 def _host_from_url(url: str) -> str:
     """Extract the hostname from *url*, lowercased."""
-    return urlparse(url).hostname or ""
+    return (urlparse(url).hostname or "").lower()
+
+
+def _normalize_fingerprint(raw: str) -> str:
+    """Strip colons + uppercase a SHA-256 fingerprint for comparison."""
+    return raw.replace(":", "").replace(" ", "").upper()
+
+
+def fetch_leaf_fingerprint(host: str, port: int = 443, timeout: float = 10.0) -> str:
+    """Connect to *host:port* and return the leaf cert SHA-256 fingerprint.
+
+    Returned as uppercase colon-less hex (e.g. ``"AB12...CD"``). Raises any
+    socket / SSL exception on failure. Verification is *disabled* during
+    capture — this function exists precisely to fingerprint untrusted chains.
+    """
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        with ctx.wrap_socket(sock, server_hostname=host) as ssock:
+            der = ssock.getpeercert(binary_form=True)
+    if not der:
+        raise RuntimeError(f"No leaf certificate returned by {host}:{port}")
+    return hashlib.sha256(der).hexdigest().upper()
+
+
+class _FingerprintPinnedAdapter(HTTPAdapter):
+    """HTTPAdapter that validates leaf cert SHA-256 against an expected pin.
+
+    Built on urllib3's ``assert_fingerprint`` — exact-match fingerprint
+    overrides CA-chain validation. A mismatch raises ``SSLError`` with no
+    fallback; that is the desired behavior (refuse-on-mismatch).
+    """
+
+    def __init__(self, *args, fingerprint: str, **kwargs) -> None:
+        self._fingerprint = _normalize_fingerprint(fingerprint)
+        super().__init__(*args, **kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        pool_kwargs["assert_fingerprint"] = self._fingerprint
+        # When fingerprint-pinning, CA verification is bypassed in favor of the
+        # exact-match check. This is by design: gov hosts often have broken
+        # chains but stable leaf certs.
+        pool_kwargs["cert_reqs"] = "CERT_NONE"
+        self.poolmanager = PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            **pool_kwargs,
+        )
 
 
 def government_session(base_url: str) -> requests.Session:
     """Return a :class:`requests.Session` configured for *base_url*.
 
-    If the host portion of *base_url* is in :data:`INSECURE_HOSTS`, SSL
-    certificate verification is disabled on the returned session and a
-    warning is logged.  Otherwise the session uses normal (verified) TLS.
+    Trust resolution order:
 
-    The session is pre-configured with a reasonable ``User-Agent`` header
-    and a default timeout adapter is **not** injected (callers should pass
-    ``timeout=`` on each request or rely on the library default).  The
-    ``DEFAULT_TIMEOUT`` constant is exported for convenience.
+    1. If the host has a pinned leaf fingerprint in :data:`HOST_FINGERPRINTS`,
+       a custom adapter validates the cert against that fingerprint. The
+       session is otherwise behaving as if ``verify=True``.
+    2. If the host is in :data:`INSECURE_HOSTS`, SSL verification is disabled
+       and a warning is logged. (Fallback for hosts whose chains are too
+       unstable to pin.)
+    3. Otherwise, normal CA-verified TLS.
     """
     session = requests.Session()
     session.headers.update({"User-Agent": DEFAULT_USER_AGENT})
 
     host = _host_from_url(base_url)
 
-    if host in INSECURE_HOSTS:
+    if host in HOST_FINGERPRINTS:
+        fingerprint, captured_at, _source = HOST_FINGERPRINTS[host]
+        adapter = _FingerprintPinnedAdapter(fingerprint=fingerprint)
+        session.mount("https://", adapter)
+        session.verify = True
+        logger.info(
+            "TLS fingerprint-pinning active for %s (captured %s)",
+            host,
+            captured_at,
+        )
+    elif host in INSECURE_HOSTS:
         session.verify = False
-        logger.warning("SSL verification disabled for allowlisted host: %s", host)
+        logger.warning(
+            "SSL verification disabled for allowlisted host: %s "
+            "(consider capturing a fingerprint — see scripts/utils/capture_tls_fingerprint.py)",
+            host,
+        )
     else:
         session.verify = True
 

--- a/scripts/utils/audit_silent_excepts.py
+++ b/scripts/utils/audit_silent_excepts.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Silent bare-except auditor.
+
+Scans `apps/` for `except Exception:` blocks whose body is only `pass`,
+`continue`, or `...` — i.e. the failure is swallowed without logging.
+Returns non-zero exit when any are found, so it can wire into CI.
+
+Override pattern: add `# noqa: BLE001` on the `except` line to opt out.
+Override should include a one-line justification comment above it.
+
+Usage:
+    python scripts/utils/audit_silent_excepts.py            # scan apps/
+    python scripts/utils/audit_silent_excepts.py --json     # machine output
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCAN_DIRS = ["apps"]
+EXCLUDE_PARTS = {"__pycache__", "migrations", "node_modules", ".venv", "venv"}
+
+
+def is_silent_body(body: list[ast.stmt]) -> bool:
+    """A handler body is 'silent' when it does only pass/continue/Ellipsis."""
+    if not body:
+        return False
+    for stmt in body:
+        if isinstance(stmt, ast.Pass):
+            continue
+        if isinstance(stmt, ast.Continue):
+            continue
+        if (
+            isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Constant)
+            and stmt.value.value is Ellipsis
+        ):
+            continue
+        return False
+    return True
+
+
+def has_noqa(source_line: str) -> bool:
+    return "noqa: BLE001" in source_line or "noqa:BLE001" in source_line
+
+
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
+        return []
+    lines = text.splitlines()
+    findings: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        # Only flag bare except or `except Exception` / `except BaseException`
+        exc_type = node.type
+        is_broad = exc_type is None or (
+            isinstance(exc_type, ast.Name)
+            and exc_type.id in {"Exception", "BaseException"}
+        )
+        if not is_broad:
+            continue
+        if not is_silent_body(node.body):
+            continue
+        # Scan the handler-header span (from `except` line to the first body
+        # line) for `# noqa: BLE001`. Black sometimes wraps a long-comment
+        # `except Exception:  # noqa: ...` into multi-line form, putting the
+        # noqa on a later line.
+        first_body_line = node.body[0].lineno if node.body else node.lineno + 1
+        header_lines = lines[node.lineno - 1 : first_body_line - 1]
+        if any(has_noqa(line) for line in header_lines):
+            continue
+        line_idx = node.lineno - 1
+        findings.append(
+            (node.lineno, lines[line_idx].strip() if line_idx < len(lines) else "")
+        )
+    return findings
+
+
+def iter_python_files() -> list[Path]:
+    files: list[Path] = []
+    for top in SCAN_DIRS:
+        base = ROOT / top
+        if not base.exists():
+            continue
+        for p in base.rglob("*.py"):
+            if any(part in EXCLUDE_PARTS for part in p.parts):
+                continue
+            files.append(p)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human output"
+    )
+    args = parser.parse_args()
+
+    all_findings: dict[str, list[tuple[int, str]]] = {}
+    for path in iter_python_files():
+        hits = scan_file(path)
+        if hits:
+            rel = path.relative_to(ROOT).as_posix()
+            all_findings[rel] = hits
+
+    total = sum(len(v) for v in all_findings.values())
+
+    if args.json:
+        print(
+            json.dumps(
+                {"total": total, "findings": all_findings},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        if total == 0:
+            print("OK: no silent bare-except blocks found in apps/.")
+        else:
+            print(f"FAIL: {total} silent bare-except block(s) found:\n")
+            for rel, hits in sorted(all_findings.items()):
+                for lineno, snippet in hits:
+                    print(f"  {rel}:{lineno}: {snippet}")
+            print(
+                "\nFix: replace silent `pass`/`continue` with "
+                "`logger.debug(..., exc_info=True)` or catch a narrower exception.\n"
+                "Override (rare, justify above the line): add `# noqa: BLE001`."
+            )
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/utils/capture_tls_fingerprint.py
+++ b/scripts/utils/capture_tls_fingerprint.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Capture the leaf TLS certificate SHA-256 fingerprint for a host.
+
+Use this to populate ``apps.scraper.http.HOST_FINGERPRINTS``. The captured
+fingerprint pins the leaf cert so a broken CA chain no longer requires a
+blanket ``verify=False`` bypass.
+
+Usage:
+    poetry run python scripts/utils/capture_tls_fingerprint.py dof.gob.mx
+    poetry run python scripts/utils/capture_tls_fingerprint.py dof.gob.mx --port 443
+
+The output prints a ready-to-paste entry. After pasting into
+``HOST_FINGERPRINTS``, remove the host from ``INSECURE_HOSTS``.
+
+Verify with::
+
+    poetry run python -c "from apps.scraper.http import government_session; \\
+        s = government_session('https://<host>/'); print(s.get('https://<host>/').status_code)"
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from apps.scraper.http import fetch_leaf_fingerprint  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("host", help="Hostname (e.g. dof.gob.mx)")
+    parser.add_argument("--port", type=int, default=443)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    args = parser.parse_args()
+
+    try:
+        fingerprint = fetch_leaf_fingerprint(args.host, args.port, args.timeout)
+    except Exception as exc:  # noqa: BLE001 — diagnostic CLI, surface anything
+        print(f"FAIL: could not capture fingerprint for {args.host}:{args.port}: {exc}")
+        return 1
+
+    today = dt.date.today().isoformat()
+    source_url = f"https://{args.host}/"
+    fp_pretty = ":".join(fingerprint[i : i + 2] for i in range(0, len(fingerprint), 2))
+
+    print("OK — fingerprint captured.\n")
+    print(f"  host         : {args.host}")
+    print(f"  fingerprint  : {fp_pretty}")
+    print(f"  captured_at  : {today}\n")
+    print("Add to apps/scraper/http.py:HOST_FINGERPRINTS:\n")
+    print(
+        f'    "{args.host}": (\n'
+        f'        "{fingerprint}",\n'
+        f'        "{today}",\n'
+        f'        "{source_url}",\n'
+        f"    ),"
+    )
+    print(
+        "\nThen remove the host from INSECURE_HOSTS (if present) so the "
+        "fingerprint path takes precedence."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scraper/test_http.py
+++ b/tests/scraper/test_http.py
@@ -1,0 +1,196 @@
+"""
+Tests for ``apps.scraper.http`` — government TLS session factory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from apps.scraper import http as http_mod
+
+
+def _fake_der(payload: bytes = b"x") -> bytes:
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# _host_from_url
+# ---------------------------------------------------------------------------
+
+
+def test_host_from_url_extracts_hostname_lowercased():
+    assert http_mod._host_from_url("https://DOF.gob.mx/some/path") == "dof.gob.mx"
+
+
+def test_host_from_url_handles_missing_scheme():
+    # urlparse returns no hostname for bare strings — function must not crash
+    assert http_mod._host_from_url("dof.gob.mx") == ""
+
+
+# ---------------------------------------------------------------------------
+# _normalize_fingerprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("aa:bb:cc", "AABBCC"),
+        ("AA BB CC", "AABBCC"),
+        ("aabbcc", "AABBCC"),
+    ],
+)
+def test_normalize_fingerprint(raw, expected):
+    assert http_mod._normalize_fingerprint(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# fetch_leaf_fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_leaf_fingerprint_returns_sha256_of_der():
+    der = _fake_der(b"hello-world")
+    expected = hashlib.sha256(der).hexdigest().upper()
+
+    fake_ssock = type("FakeSSock", (), {"getpeercert": lambda self, binary_form: der})()
+
+    class _CtxMgr:
+        def __enter__(self):
+            return fake_ssock
+
+        def __exit__(self, *args):
+            return False
+
+    class _SocketCtx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    fake_ctx = type(
+        "FakeCtx",
+        (),
+        {
+            "check_hostname": True,
+            "verify_mode": None,
+            "wrap_socket": lambda self, sock, server_hostname: _CtxMgr(),
+        },
+    )()
+
+    with patch(
+        "apps.scraper.http.ssl.create_default_context", return_value=fake_ctx
+    ), patch("apps.scraper.http.socket.create_connection", return_value=_SocketCtx()):
+        result = http_mod.fetch_leaf_fingerprint("dof.gob.mx")
+    assert result == expected
+
+
+def test_fetch_leaf_fingerprint_raises_when_no_cert():
+    fake_ssock = type(
+        "FakeSSock", (), {"getpeercert": lambda self, binary_form: None}
+    )()
+
+    class _CtxMgr:
+        def __enter__(self):
+            return fake_ssock
+
+        def __exit__(self, *args):
+            return False
+
+    class _SocketCtx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    fake_ctx = type(
+        "FakeCtx",
+        (),
+        {
+            "check_hostname": True,
+            "verify_mode": None,
+            "wrap_socket": lambda self, sock, server_hostname: _CtxMgr(),
+        },
+    )()
+
+    with patch(
+        "apps.scraper.http.ssl.create_default_context", return_value=fake_ctx
+    ), patch("apps.scraper.http.socket.create_connection", return_value=_SocketCtx()):
+        with pytest.raises(RuntimeError, match="No leaf certificate"):
+            http_mod.fetch_leaf_fingerprint("dof.gob.mx")
+
+
+# ---------------------------------------------------------------------------
+# government_session — trust-resolution paths
+# ---------------------------------------------------------------------------
+
+
+def test_session_uses_normal_tls_for_unknown_host():
+    sess = http_mod.government_session("https://example.com/")
+    assert sess.verify is True
+
+
+def test_session_disables_verify_for_insecure_host(caplog):
+    caplog.set_level(logging.WARNING, logger="apps.scraper.http")
+    sess = http_mod.government_session("https://dof.gob.mx/some/path")
+    assert sess.verify is False
+    assert any("dof.gob.mx" in rec.getMessage() for rec in caplog.records)
+
+
+def test_session_pins_fingerprint_when_known(caplog, monkeypatch):
+    fingerprint = "AB" * 32  # 64 hex chars = SHA-256
+    monkeypatch.setitem(
+        http_mod.HOST_FINGERPRINTS,
+        "pinned.example.gob.mx",
+        (fingerprint, "2026-04-27", "https://pinned.example.gob.mx/"),
+    )
+
+    caplog.set_level(logging.INFO, logger="apps.scraper.http")
+    sess = http_mod.government_session("https://pinned.example.gob.mx/")
+
+    assert sess.verify is True
+    # An adapter was mounted on https://; verify it's the pinned variant
+    adapter = sess.get_adapter("https://pinned.example.gob.mx/")
+    assert isinstance(adapter, http_mod._FingerprintPinnedAdapter)
+    assert adapter._fingerprint == fingerprint  # already uppercase
+    # Log line announces pinning
+    assert any("fingerprint-pinning" in rec.getMessage() for rec in caplog.records)
+
+
+def test_session_fingerprint_takes_precedence_over_insecure_list(monkeypatch):
+    """If a host appears in BOTH HOST_FINGERPRINTS and INSECURE_HOSTS, pin wins."""
+    fingerprint = "CD" * 32
+    monkeypatch.setitem(
+        http_mod.HOST_FINGERPRINTS,
+        "dof.gob.mx",
+        (fingerprint, "2026-04-27", "https://dof.gob.mx/"),
+    )
+
+    sess = http_mod.government_session("https://dof.gob.mx/")
+    # verify must be True (fingerprint adapter takes over) — not False
+    assert sess.verify is True
+    adapter = sess.get_adapter("https://dof.gob.mx/")
+    assert isinstance(adapter, http_mod._FingerprintPinnedAdapter)
+
+
+def test_session_user_agent_set():
+    sess = http_mod.government_session("https://example.com/")
+    assert "Tezca" in sess.headers["User-Agent"]
+
+
+# ---------------------------------------------------------------------------
+# _FingerprintPinnedAdapter — adapter-level checks
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_adapter_initializes_poolmanager_with_fingerprint():
+    adapter = http_mod._FingerprintPinnedAdapter(fingerprint="ab:cd:ef")
+    assert adapter._fingerprint == "ABCDEF"
+    # init_poolmanager was called by HTTPAdapter.__init__; poolmanager exists
+    assert adapter.poolmanager is not None


### PR DESCRIPTION
## Summary

A+ remediation: **WS3 enforcement** + **WS7 H7 architecture fix**.

### WS3 — silent-except CI gate
- New \`scripts/utils/audit_silent_excepts.py\` AST-walks \`apps/\` and flags any \`except Exception:\` whose body is only \`pass\` / \`continue\` / \`...\`. Override: \`# noqa: BLE001\`.
- Wired into \`.github/workflows/ci.yml\` so a new silent except blocks the merge.
- The audit caught 7 silent excepts that PR #56's grep-based pass missed (multi-line \`except (Exception):\` form + \`except Exception as e: pass\`); all fixed in this PR (3 with documented \`# noqa\`, 4 converted to \`logger.debug(..., exc_info=True)\`).

### WS7 H7 — TLS fingerprint pinning
- \`apps/scraper/http.py\` resolves TLS trust through two layers:
  1. \`HOST_FINGERPRINTS\` (preferred) — pinned leaf SHA-256 via urllib3 \`assert_fingerprint\`. Mismatch fails the connection. Refuse-on-mismatch.
  2. \`INSECURE_HOSTS\` (fallback) — only for chains too unstable to pin.
- New \`scripts/utils/capture_tls_fingerprint.py\` captures fingerprints from a live host with a ready-to-paste output block.
- 13 new tests in \`tests/scraper/test_http.py\` covering both trust paths.
- \`SECURITY.md\` documents the two-layer model.
- \`CLAUDE.md\` Known Issues: H7 demoted from 🟠 (MITM risk, open) to 🟡 (architecture landed; capture sweep is the residual operator task on stable network).

## Test plan
- [x] pytest: 1581 passed, 18 skipped, 0 failures (+13 from \`test_http.py\`)
- [x] \`audit_silent_excepts.py\`: 0 findings
- [x] black + isort: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)