### PR TITLE
test(scraper+web): cover law_registry/sinec/pnt; ratchet backend 48→51 + frontend gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
       run: poetry run python scripts/utils/audit_silent_excepts.py
 
     - name: Run Pytest with coverage
-      # Coverage floor: ratcheted from 44% (baseline) → 48% (Apr 2026) as
-      # WS1 Phases 1A/1B/1C closed scheduling, parser pipeline, scjn,
-      # treaty, and playwright_base coverage gaps. Headroom: actual is ~53%.
-      # Next ratchet target: 55% once one more scraper module crosses 50%.
-      run: poetry run pytest tests/ -v --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=48
+      # Coverage floor: ratcheted 44 → 48 → 51 as WS1 Phases 1A/1B/1C
+      # closed scheduling, parser pipeline, scjn, treaty, playwright_base,
+      # law_registry, sinec, and pnt coverage gaps. Headroom: actual is ~56%.
+      # Next ratchet target: 55% once two more 0% scraper modules cross 50%.
+      run: poetry run pytest tests/ -v --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=51
       env:
         PYTHONPATH: apps:.
 

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -21,10 +21,11 @@ export default defineConfig({
             reporter: ['text', 'json', 'html'],
             // `all: true` widens the denominator to every source file under
             // the project, not just files imported by tests. Thresholds are
-            // pinned to the observed floor minus ~5pp so unrelated PRs don't
+            // pinned ~3pp below the observed floor so unrelated PRs don't
             // trip the gate; ratchet up as component coverage grows.
             // Observed floor (2026-04-27, all:true with full include scope):
             // stmts 56.44, branches 49.68, funcs 52.09, lines 57.66.
+            // WS2 Phase 2C lock target: ≥50/40/50/50.
             all: true,
             include: ['app/**', 'components/**', 'hooks/**', 'lib/**', 'contexts/**'],
             exclude: [
@@ -37,10 +38,10 @@ export default defineConfig({
                 'e2e/**',
             ],
             thresholds: {
-                statements: 51,
-                branches: 44,
-                functions: 47,
-                lines: 52,
+                statements: 53,
+                branches: 46,
+                functions: 49,
+                lines: 54,
             },
         },
         alias: {

--- a/tests/scraper/test_law_registry.py
+++ b/tests/scraper/test_law_registry.py
@@ -1,0 +1,256 @@
+"""Tests for ``apps.scraper.utils.law_registry``.
+
+LawRegistry is a thin wrapper around a JSON file. These tests use a
+fixture-based registry written into ``tmp_path`` so we don't depend on
+the real ``data/law_registry.json`` shape and contents.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from apps.scraper.utils.law_registry import LawRegistry
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry_file(tmp_path: Path) -> Path:
+    """Write a synthetic registry to tmp and return its path."""
+    payload = {
+        "federal_laws": [
+            {
+                "id": "amparo",
+                "name": "Ley de Amparo",
+                "short_name": "Amparo",
+                "type": "ley",
+                "slug": "amparo",
+                "expected_articles": 300,
+                "publication_date": "2013-04-02",
+                "url": "https://example.com/amparo.pdf",
+                "priority": 1,
+                "tier": "constitutional",
+                "status": "active",
+                "category": "ley",
+            },
+            {
+                "id": "iva",
+                "name": "Ley del IVA",
+                "short_name": "IVA",
+                "type": "ley",
+                "slug": "iva",
+                "expected_articles": 50,
+                "publication_date": "1978-12-29",
+                "url": "https://example.com/iva.pdf",
+                "priority": 1,
+                "tier": "fiscal",
+                "status": "active",
+                "category": "ley",
+            },
+            {
+                "id": "deprecated_law",
+                "name": "Ley Vieja",
+                "short_name": "Vieja",
+                "type": "ley",
+                "slug": "vieja",
+                "expected_articles": 0,
+                "publication_date": "1990-01-01",
+                "url": "https://example.com/vieja.pdf",
+                "priority": 2,
+                "tier": "labor",
+                "status": "deprecated",
+                "category": "ley",
+            },
+        ]
+    }
+    path = tmp_path / "law_registry.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# __init__ + _load_registry
+# ---------------------------------------------------------------------------
+
+
+def test_init_loads_registry_file(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    assert registry.count() == 3
+    assert registry.registry_path == registry_file
+
+
+def test_init_raises_when_file_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        LawRegistry(registry_path=tmp_path / "nope.json")
+
+
+def test_init_skips_reglamentos_when_disabled(registry_file):
+    registry = LawRegistry(registry_path=registry_file, include_reglamentos=False)
+    assert registry.count() == 3
+
+
+def test_init_includes_reglamentos_when_present(registry_file, tmp_path):
+    """When include_reglamentos=True and a sibling JSON exists, entries merge."""
+    reglamentos = [
+        {
+            "id": "reg_amparo",
+            "name": "Reglamento de la Ley de Amparo",
+            "url": "https://example.com/reg_amparo.pdf",
+        }
+    ]
+    (registry_file.parent / "discovered_reglamentos.json").write_text(
+        json.dumps(reglamentos), encoding="utf-8"
+    )
+
+    registry = LawRegistry(registry_path=registry_file, include_reglamentos=True)
+    assert registry.count() == 4
+    # The reglamento gets normalised to the standard schema
+    reg = registry.get_by_id("reg_amparo")
+    assert reg is not None
+    assert reg["category"] == "reglamento"
+    assert reg["tier"] == "federal"
+    assert reg["priority"] == 2
+
+
+def test_include_reglamentos_with_no_sibling_file(registry_file):
+    """When include_reglamentos=True but no sibling file, base set is used."""
+    registry = LawRegistry(registry_path=registry_file, include_reglamentos=True)
+    assert registry.count() == 3
+
+
+# ---------------------------------------------------------------------------
+# all() — returns a copy
+# ---------------------------------------------------------------------------
+
+
+def test_all_returns_a_copy(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    laws = registry.all()
+    laws.append({"id": "injected"})
+    # Mutating the returned list must not affect the registry
+    assert registry.count() == 3
+
+
+# ---------------------------------------------------------------------------
+# get_by_id
+# ---------------------------------------------------------------------------
+
+
+def test_get_by_id_returns_match(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    law = registry.get_by_id("amparo")
+    assert law is not None
+    assert law["name"] == "Ley de Amparo"
+
+
+def test_get_by_id_returns_none_for_missing(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    assert registry.get_by_id("does_not_exist") is None
+
+
+def test_get_by_id_returns_a_copy(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    law = registry.get_by_id("amparo")
+    law["mutated"] = True
+    # Re-fetch — mutation must not have leaked
+    fresh = registry.get_by_id("amparo")
+    assert "mutated" not in fresh
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_priority_returns_matching(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    p1 = registry.filter_by_priority(1)
+    assert len(p1) == 2
+    assert all(law["priority"] == 1 for law in p1)
+
+
+def test_filter_by_priority_empty_when_no_match(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    assert registry.filter_by_priority(99) == []
+
+
+def test_filter_by_tier(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    fiscal = registry.filter_by_tier("fiscal")
+    assert len(fiscal) == 1
+    assert fiscal[0]["id"] == "iva"
+
+
+def test_filter_by_category(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    leyes = registry.filter_by_category("ley")
+    assert len(leyes) == 3
+
+
+def test_filter_by_status_default_is_active(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    active = registry.filter_by_status()  # defaults to "active"
+    assert len(active) == 2
+    assert all(law["status"] == "active" for law in active)
+
+
+def test_filter_by_status_explicit(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    deprecated = registry.filter_by_status("deprecated")
+    assert len(deprecated) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_ids / count
+# ---------------------------------------------------------------------------
+
+
+def test_get_ids_returns_all_ids(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    ids = registry.get_ids()
+    assert set(ids) == {"amparo", "iva", "deprecated_law"}
+
+
+def test_count_matches_data(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    assert registry.count() == 3
+
+
+# ---------------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------------
+
+
+def test_summary_aggregates_correctly(registry_file):
+    registry = LawRegistry(registry_path=registry_file)
+    summary = registry.summary()
+    assert summary["total_laws"] == 3
+    assert summary["by_priority"][1] == 2
+    assert summary["by_priority"][2] == 1
+    assert summary["by_tier"]["constitutional"] == 1
+    assert summary["by_tier"]["fiscal"] == 1
+    assert summary["by_tier"]["labor"] == 1
+    assert summary["by_status"]["active"] == 2
+    assert summary["by_status"]["deprecated"] == 1
+
+
+def test_count_by_field_handles_missing_value(registry_file, tmp_path):
+    """Laws without the requested field are bucketed under 'unknown'."""
+    payload = {
+        "federal_laws": [
+            {"id": "a", "name": "A"},  # no tier/status/priority
+            {"id": "b", "name": "B", "tier": "fiscal"},
+        ]
+    }
+    path = tmp_path / "registry.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    registry = LawRegistry(registry_path=path)
+    summary = registry.summary()
+    assert summary["by_tier"]["unknown"] == 1
+    assert summary["by_tier"]["fiscal"] == 1

--- a/tests/scraper/test_pnt_scraper.py
+++ b/tests/scraper/test_pnt_scraper.py
@@ -1,0 +1,478 @@
+"""Tests for ``apps.scraper.municipal.pnt_scraper``.
+
+PNT is the Plataforma Nacional de Transparencia. The scraper hits a
+JSON API, so tests stub `_api_post` / `_api_get` at the boundary and
+exercise the orchestration + extraction logic.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.scraper.municipal.pnt_scraper import (
+    INEGI_STATE_CODES,
+    REGULATORY_KEYWORDS,
+    PNTMunicipalScraper,
+    _sanitize_filename,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_filename_replaces_unsafe_chars():
+    out = _sanitize_filename("Reglamento de Aguas/Drenaje (2024)")
+    # Spaces, slashes, parentheses replaced with underscores
+    assert "/" not in out
+    assert "(" not in out
+    assert " " not in out
+
+
+def test_sanitize_filename_truncates():
+    long_name = "x" * 200
+    assert len(_sanitize_filename(long_name, max_length=50)) <= 50
+
+
+def test_sanitize_filename_preserves_periods_and_hyphens():
+    out = _sanitize_filename("file-name.v2.pdf")
+    assert "." in out
+    assert "-" in out
+
+
+def test_regulatory_keywords_match():
+    assert REGULATORY_KEYWORDS.search("Reglamento de obras")
+    assert REGULATORY_KEYWORDS.search("Bando municipal")
+    assert REGULATORY_KEYWORDS.search("Código fiscal")
+    assert REGULATORY_KEYWORDS.search("Manual de procedimientos")
+    assert not REGULATORY_KEYWORDS.search("Otro documento")
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+def test_init_succeeds_for_known_state(tmp_path):
+    s = PNTMunicipalScraper(state_key="jalisco")
+    assert s.state_key == "jalisco"
+    assert s.state_code == INEGI_STATE_CODES["jalisco"]
+    assert s.municipality_filter is None
+
+
+def test_init_with_municipality_filter():
+    s = PNTMunicipalScraper(state_key="jalisco", municipality="Guadalajara")
+    assert s.municipality_filter == "Guadalajara"
+
+
+def test_init_raises_for_unknown_state():
+    with pytest.raises(ValueError, match="Unknown state key"):
+        PNTMunicipalScraper(state_key="not_a_state")
+
+
+def test_init_uses_custom_obligation_id():
+    s = PNTMunicipalScraper(state_key="jalisco", obligation_id="II")
+    assert s.obligation_id == "II"
+
+
+# ---------------------------------------------------------------------------
+# Fixture: scraper without network setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scraper():
+    """Build a scraper without invoking the real session setup."""
+    s = PNTMunicipalScraper.__new__(PNTMunicipalScraper)
+    s.state_key = "jalisco"
+    s.state_code = INEGI_STATE_CODES["jalisco"]
+    s.municipality_filter = None
+    s.obligation_id = "I"
+    s.session = MagicMock()
+    s.last_request_time = 0.0
+    s.config = {"name": "PNT-jalisco", "state": "Jalisco"}
+    s.min_request_interval = 2.0
+    return s
+
+
+# ---------------------------------------------------------------------------
+# _api_post / _api_get
+# ---------------------------------------------------------------------------
+
+
+def test_api_post_returns_parsed_json(scraper):
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"results": [{"id": 1}]}
+    fake_resp.raise_for_status = MagicMock()
+    scraper.session.post.return_value = fake_resp
+    with patch.object(scraper, "_rate_limit"):
+        out = scraper._api_post("subjects", {"q": "x"})
+    assert out == {"results": [{"id": 1}]}
+
+
+def test_api_post_returns_none_on_exception(scraper):
+    scraper.session.post.side_effect = RuntimeError("boom")
+    with patch.object(scraper, "_rate_limit"):
+        assert scraper._api_post("subjects", {}) is None
+
+
+def test_api_get_returns_parsed_json(scraper):
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = [{"a": 1}]
+    fake_resp.raise_for_status = MagicMock()
+    scraper.session.get.return_value = fake_resp
+    with patch.object(scraper, "_rate_limit"):
+        out = scraper._api_get("https://x.com")
+    assert out == [{"a": 1}]
+
+
+def test_api_get_returns_none_on_exception(scraper):
+    scraper.session.get.side_effect = RuntimeError("boom")
+    with patch.object(scraper, "_rate_limit"):
+        assert scraper._api_get("https://x.com") is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_subjects
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_subjects_returns_list(scraper):
+    with patch.object(
+        scraper,
+        "_api_post",
+        return_value={"results": [{"id": "s1", "name": "Guadalajara"}]},
+    ):
+        out = scraper.fetch_subjects()
+    assert len(out) == 1
+    assert out[0]["name"] == "Guadalajara"
+
+
+def test_fetch_subjects_handles_list_response(scraper):
+    """Some PNT endpoints return a bare list instead of a wrapper."""
+    with patch.object(scraper, "_api_post", return_value=[{"id": "s1", "name": "x"}]):
+        out = scraper.fetch_subjects()
+    assert len(out) == 1
+
+
+def test_fetch_subjects_returns_empty_on_failure(scraper):
+    with patch.object(scraper, "_api_post", return_value=None):
+        assert scraper.fetch_subjects() == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_records / fetch_all_records
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_records_passes_pagination_params(scraper):
+    with patch.object(scraper, "_api_post", return_value={"results": []}) as m:
+        scraper.fetch_records("s1", page=3, page_size=50)
+    payload = m.call_args.args[1]
+    assert payload["subjectId"] == "s1"
+    assert payload["page"] == 3
+    assert payload["pageSize"] == 50
+
+
+def test_fetch_all_records_paginates_until_empty(scraper):
+    """Stops when API returns fewer records than page_size."""
+    page1 = {"results": [{"id": i} for i in range(100)], "totalCount": 150}
+    page2 = {"results": [{"id": i} for i in range(50)], "totalCount": 150}
+    with patch.object(scraper, "fetch_records", side_effect=[page1, page2]):
+        out = scraper.fetch_all_records("s1")
+    assert len(out) == 150
+
+
+def test_fetch_all_records_stops_when_total_reached(scraper):
+    page1 = {"results": [{"id": i} for i in range(100)], "totalCount": 100}
+    with patch.object(scraper, "fetch_records", side_effect=[page1, {"results": []}]):
+        out = scraper.fetch_all_records("s1")
+    assert len(out) == 100
+
+
+def test_fetch_all_records_handles_none_response(scraper):
+    with patch.object(scraper, "fetch_records", return_value=None):
+        out = scraper.fetch_all_records("s1")
+    assert out == []
+
+
+def test_fetch_all_records_handles_list_response(scraper):
+    """List response (not dict) — extends and stops."""
+    with patch.object(scraper, "fetch_records", return_value=[{"id": 1}]):
+        out = scraper.fetch_all_records("s1")
+    assert out == [{"id": 1}]
+
+
+# ---------------------------------------------------------------------------
+# _extract_document_url
+# ---------------------------------------------------------------------------
+
+
+def test_extract_document_url_finds_known_field(scraper):
+    record = {"documentUrl": "https://example.com/doc.pdf"}
+    assert scraper._extract_document_url(record) == "https://example.com/doc.pdf"
+
+
+def test_extract_document_url_finds_alternate_field(scraper):
+    record = {"hipervinculo": "https://x.com/doc.pdf"}
+    assert scraper._extract_document_url(record) == "https://x.com/doc.pdf"
+
+
+def test_extract_document_url_finds_nested_field(scraper):
+    record = {
+        "fields": [
+            {"label": "URL", "value": "https://example.com/nested.pdf"},
+            {"label": "title", "value": "Some Title"},
+        ]
+    }
+    assert scraper._extract_document_url(record) == "https://example.com/nested.pdf"
+
+
+def test_extract_document_url_returns_none_when_no_url(scraper):
+    record = {"name": "no url here"}
+    assert scraper._extract_document_url(record) is None
+
+
+def test_extract_document_url_skips_non_http_values(scraper):
+    record = {"url": "ftp://example.com/x"}
+    assert scraper._extract_document_url(record) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_document_title
+# ---------------------------------------------------------------------------
+
+
+def test_extract_document_title_uses_known_field(scraper):
+    record = {"denominacion": "Reglamento de Aguas"}
+    assert scraper._extract_document_title(record) == "Reglamento de Aguas"
+
+
+def test_extract_document_title_handles_alternate_field(scraper):
+    record = {"name": "Some Document"}
+    assert scraper._extract_document_title(record) == "Some Document"
+
+
+def test_extract_document_title_uses_nested_field(scraper):
+    record = {
+        "fields": [
+            {"label": "Denominación", "value": "Bando Municipal"},
+            {"label": "Other", "value": "ignored"},
+        ]
+    }
+    assert scraper._extract_document_title(record) == "Bando Municipal"
+
+
+def test_extract_document_title_falls_back_to_id(scraper):
+    record = {"id": "rec-123"}
+    out = scraper._extract_document_title(record)
+    assert "rec-123" in out
+
+
+def test_extract_document_title_skips_short_values(scraper):
+    """Values <= 3 chars long are skipped."""
+    record = {"denominacion": "X", "name": "Real Title"}
+    assert scraper._extract_document_title(record) == "Real Title"
+
+
+# ---------------------------------------------------------------------------
+# _extract_publication_date
+# ---------------------------------------------------------------------------
+
+
+def test_extract_publication_date_finds_known_field(scraper):
+    record = {"fechaPublicacion": "2024-01-15"}
+    assert scraper._extract_publication_date(record) == "2024-01-15"
+
+
+def test_extract_publication_date_alternate_field(scraper):
+    record = {"date": "2023-06-30"}
+    assert scraper._extract_publication_date(record) == "2023-06-30"
+
+
+def test_extract_publication_date_returns_none_when_missing(scraper):
+    assert scraper._extract_publication_date({}) is None
+
+
+def test_extract_publication_date_skips_short_strings(scraper):
+    """Strings shorter than 8 chars are skipped (likely not a real date)."""
+    record = {"date": "short"}
+    assert scraper._extract_publication_date(record) is None
+
+
+# ---------------------------------------------------------------------------
+# _is_regulatory_document
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        ("Reglamento de obras", True),
+        ("Bando municipal", True),
+        ("Código fiscal", True),
+        ("Decreto número 42", True),
+        ("Lineamientos de transparencia", True),
+        ("Convocatoria", False),
+        ("Acta de sesión", False),
+    ],
+)
+def test_is_regulatory_document(scraper, title, expected):
+    assert scraper._is_regulatory_document(title) is expected
+
+
+# ---------------------------------------------------------------------------
+# _clean_municipality_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,cleaned",
+    [
+        ("H. Ayuntamiento de Guadalajara", "Guadalajara"),
+        ("Ayuntamiento de Monterrey", "Monterrey"),
+        ("Municipio de Puebla", "Puebla"),
+        ("Ayuntamiento Municipal de León", "León"),
+        ("Gobierno Municipal de Mérida", "Mérida"),
+        ("Just Plain Name", "Just Plain Name"),
+    ],
+)
+def test_clean_municipality_name(raw, cleaned):
+    assert PNTMunicipalScraper._clean_municipality_name(raw) == cleaned
+
+
+# ---------------------------------------------------------------------------
+# list_available_states
+# ---------------------------------------------------------------------------
+
+
+def test_list_available_states_returns_sorted_list():
+    states = PNTMunicipalScraper.list_available_states()
+    assert "jalisco" in states
+    assert states == sorted(states)
+
+
+# ---------------------------------------------------------------------------
+# scrape_catalog — orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_scrape_catalog_returns_empty_when_no_subjects(scraper):
+    with patch.object(scraper, "fetch_subjects", return_value=[]):
+        assert scraper.scrape_catalog() == []
+
+
+def test_scrape_catalog_filters_to_municipality(scraper):
+    """When municipality_filter is set, only matching subjects proceed."""
+    scraper.municipality_filter = "Guadalajara"
+    with patch.object(
+        scraper,
+        "fetch_subjects",
+        return_value=[
+            {"id": "s1", "name": "H. Ayuntamiento de Guadalajara"},
+            {"id": "s2", "name": "H. Ayuntamiento de Zapopan"},
+        ],
+    ), patch.object(scraper, "fetch_all_records", return_value=[]) as mock_records:
+        scraper.scrape_catalog()
+    # Only the matching subject's records were fetched
+    assert mock_records.call_count == 1
+
+
+def test_scrape_catalog_returns_empty_when_filter_misses(scraper):
+    scraper.municipality_filter = "DoesNotExist"
+    with patch.object(
+        scraper,
+        "fetch_subjects",
+        return_value=[{"id": "s1", "name": "Guadalajara"}],
+    ):
+        assert scraper.scrape_catalog() == []
+
+
+def test_scrape_catalog_extracts_law_dicts(scraper):
+    subjects = [{"id": "s1", "name": "Ayuntamiento de Guadalajara"}]
+    records = [
+        {
+            "id": "rec1",
+            "denominacion": "Reglamento de Aguas",
+            "documentUrl": "https://example.com/aguas.pdf",
+            "fechaPublicacion": "2024-01-15",
+        }
+    ]
+    with patch.object(scraper, "fetch_subjects", return_value=subjects), patch.object(
+        scraper, "fetch_all_records", return_value=records
+    ), patch.object(scraper, "validate_law_data", return_value=True), patch.object(
+        scraper, "extract_category", return_value="reglamento"
+    ):
+        laws = scraper.scrape_catalog()
+
+    assert len(laws) == 1
+    assert laws[0]["name"] == "Reglamento de Aguas"
+    assert laws[0]["municipality"] == "Guadalajara"
+    assert laws[0]["url"] == "https://example.com/aguas.pdf"
+    assert laws[0]["is_regulatory"] is True
+
+
+def test_scrape_catalog_dedupes_by_url(scraper):
+    """Two records with the same doc URL produce one law entry."""
+    subjects = [
+        {"id": "s1", "name": "M1"},
+        {"id": "s2", "name": "M2"},
+    ]
+    common_record = {
+        "id": "rec1",
+        "denominacion": "Reglamento X",
+        "documentUrl": "https://example.com/same.pdf",
+    }
+    with patch.object(scraper, "fetch_subjects", return_value=subjects), patch.object(
+        scraper, "fetch_all_records", return_value=[common_record]
+    ), patch.object(scraper, "validate_law_data", return_value=True), patch.object(
+        scraper, "extract_category", return_value="reglamento"
+    ):
+        laws = scraper.scrape_catalog()
+    assert len(laws) == 1
+
+
+def test_scrape_catalog_skips_records_without_url(scraper):
+    subjects = [{"id": "s1", "name": "M1"}]
+    records = [
+        {"id": "rec1", "denominacion": "No URL"},
+        {
+            "id": "rec2",
+            "denominacion": "Has URL",
+            "documentUrl": "https://example.com/x.pdf",
+        },
+    ]
+    with patch.object(scraper, "fetch_subjects", return_value=subjects), patch.object(
+        scraper, "fetch_all_records", return_value=records
+    ), patch.object(scraper, "validate_law_data", return_value=True), patch.object(
+        scraper, "extract_category", return_value="reglamento"
+    ):
+        laws = scraper.scrape_catalog()
+    assert len(laws) == 1
+
+
+def test_scrape_catalog_regulatory_only_filters(scraper):
+    laws_in = [
+        {"name": "Reglamento X", "is_regulatory": True},
+        {"name": "Acta", "is_regulatory": False},
+    ]
+    with patch.object(scraper, "scrape_catalog", return_value=laws_in):
+        out = scraper.scrape_catalog_regulatory_only()
+    assert len(out) == 1
+    assert out[0]["name"] == "Reglamento X"
+
+
+# ---------------------------------------------------------------------------
+# save_catalog
+# ---------------------------------------------------------------------------
+
+
+def test_save_catalog_writes_json(scraper, tmp_path):
+    out = tmp_path / "out" / "catalog.json"
+    laws = [{"name": "X", "url": "y"}]
+    scraper.save_catalog(laws, str(out))
+    assert out.exists()
+    assert json.loads(out.read_text(encoding="utf-8")) == laws

--- a/tests/scraper/test_sinec_scraper.py
+++ b/tests/scraper/test_sinec_scraper.py
@@ -1,0 +1,418 @@
+"""Tests for ``apps.scraper.federal.sinec_scraper``.
+
+Covers pure helpers + HTTP-coupled paths via mocked sessions. Same
+pattern as test_treaty_scraper_full.py and test_scjn_scraper_full.py.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from bs4 import BeautifulSoup
+
+from apps.scraper.federal.sinec_scraper import (
+    SinecScraper,
+    _clean_text,
+    _extract_agency_from_nom,
+    _extract_date,
+    _normalize_status,
+    _normalize_text,
+    _resolve_agency_name,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_text_strips_accents_and_lowers():
+    assert _normalize_text("Vigéntè") == "vigente"
+    assert _normalize_text("  Multiple   Spaces  ") == "multiple spaces"
+
+
+def test_clean_text_collapses_whitespace():
+    assert _clean_text("  multiple   spaces\n\there  ") == "multiple spaces here"
+
+
+def test_normalize_status_canonical_values():
+    assert _normalize_status("Vigente") == "vigente"
+    assert _normalize_status("EN VIGOR") == "vigente"
+    assert _normalize_status("Cancelada") == "cancelada"
+    assert _normalize_status("CANCELADO") == "cancelada"
+    assert _normalize_status("En proyecto") == "en_proyecto"
+    assert _normalize_status("Proyecto") == "en_proyecto"
+
+
+def test_normalize_status_passthrough_when_no_match():
+    out = _normalize_status("custom-status")
+    assert out == "custom-status"
+
+
+def test_extract_agency_from_nom_three_part():
+    assert _extract_agency_from_nom("NOM-001-SSA1-2010") == "SSA1"
+    assert _extract_agency_from_nom("NOM-059-SEMARNAT-2010") == "SEMARNAT"
+
+
+def test_extract_agency_from_nom_handles_short_strings():
+    assert _extract_agency_from_nom("nom-001") == ""
+    assert _extract_agency_from_nom("") == ""
+
+
+def test_resolve_agency_name_known_abbreviation():
+    assert "Salud" in _resolve_agency_name("SSA")
+    assert "Medio Ambiente" in _resolve_agency_name("SEMARNAT")
+
+
+def test_resolve_agency_name_prefix_match():
+    """SSA1 should resolve to SSA's full name via prefix matching."""
+    assert "Salud" in _resolve_agency_name("SSA1")
+
+
+def test_resolve_agency_name_passthrough_for_unknown():
+    assert _resolve_agency_name("UNKNOWN-AGENCY") == "UNKNOWN-AGENCY"
+
+
+def test_extract_date_dd_slash_mm_yyyy():
+    assert _extract_date("Publicado 15/03/2024") == "2024-03-15"
+
+
+def test_extract_date_dd_dash_mm_yyyy():
+    assert _extract_date("DOF: 15-03-2024") == "2024-03-15"
+
+
+def test_extract_date_iso():
+    assert _extract_date("2024-01-15") == "2024-01-15"
+
+
+def test_extract_date_returns_empty_on_no_match():
+    assert _extract_date("no date") == ""
+    assert _extract_date("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Scraper instance setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scraper():
+    s = SinecScraper.__new__(SinecScraper)
+    s.session = MagicMock()
+    s.last_request_time = 0.0
+    s._view_state = None
+    return s
+
+
+def test_init_creates_session():
+    scraper = SinecScraper()
+    assert scraper.session is not None
+    assert scraper.last_request_time == 0.0
+    assert scraper._view_state is None
+
+
+def test_rate_limit_sleeps_when_too_fast(scraper):
+    import time
+
+    scraper.last_request_time = time.time()
+    with patch("apps.scraper.federal.sinec_scraper.time.sleep") as msleep:
+        scraper._rate_limit()
+    msleep.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _get / _post — error matrix
+# ---------------------------------------------------------------------------
+
+
+def test_get_returns_response_on_success(scraper):
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    scraper.session.get.return_value = fake_resp
+    with patch.object(scraper, "_rate_limit"):
+        out = scraper._get("https://x.com")
+    assert out is fake_resp
+
+
+def test_get_returns_none_on_4xx_non_429(scraper):
+    """Client errors (except 429) short-circuit without retry."""
+    fake_resp = MagicMock()
+    fake_resp.status_code = 404
+    err = requests.HTTPError(response=fake_resp)
+    fake_resp.raise_for_status.side_effect = err
+    scraper.session.get.return_value = fake_resp
+    with patch.object(scraper, "_rate_limit"), patch(
+        "apps.scraper.federal.sinec_scraper.time.sleep"
+    ):
+        assert scraper._get("https://x.com") is None
+
+
+def test_get_retries_on_connection_error(scraper):
+    scraper.session.get.side_effect = requests.ConnectionError
+    with patch.object(scraper, "_rate_limit"), patch(
+        "apps.scraper.federal.sinec_scraper.time.sleep"
+    ):
+        out = scraper._get("https://x.com")
+    assert out is None
+    # Should have retried up to _MAX_RETRIES times
+    assert scraper.session.get.call_count >= 2
+
+
+def test_get_returns_none_on_timeout(scraper):
+    scraper.session.get.side_effect = requests.Timeout
+    with patch.object(scraper, "_rate_limit"), patch(
+        "apps.scraper.federal.sinec_scraper.time.sleep"
+    ):
+        assert scraper._get("https://x.com") is None
+
+
+def test_get_returns_none_on_request_exception(scraper):
+    scraper.session.get.side_effect = requests.RequestException("generic")
+    with patch.object(scraper, "_rate_limit"), patch(
+        "apps.scraper.federal.sinec_scraper.time.sleep"
+    ):
+        assert scraper._get("https://x.com") is None
+
+
+def test_post_returns_response_on_success(scraper):
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    scraper.session.post.return_value = fake_resp
+    with patch.object(scraper, "_rate_limit"):
+        out = scraper._post("https://x.com", data={"key": "val"})
+    assert out is fake_resp
+
+
+def test_post_returns_none_on_4xx_non_429(scraper):
+    fake_resp = MagicMock()
+    fake_resp.status_code = 400
+    err = requests.HTTPError(response=fake_resp)
+    fake_resp.raise_for_status.side_effect = err
+    scraper.session.post.return_value = fake_resp
+    with patch.object(scraper, "_rate_limit"), patch(
+        "apps.scraper.federal.sinec_scraper.time.sleep"
+    ):
+        assert scraper._post("https://x.com", data={}) is None
+
+
+def test_post_returns_none_on_timeout(scraper):
+    scraper.session.post.side_effect = requests.Timeout
+    with patch.object(scraper, "_rate_limit"), patch(
+        "apps.scraper.federal.sinec_scraper.time.sleep"
+    ):
+        assert scraper._post("https://x.com", data={}) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_view_state
+# ---------------------------------------------------------------------------
+
+
+def test_extract_view_state_from_input_element(scraper):
+    html = '<input name="javax.faces.ViewState" value="abc123"/>'
+    out = scraper._extract_view_state(html)
+    assert out == "abc123"
+    assert scraper._view_state == "abc123"
+
+
+def test_extract_view_state_via_regex_fallback(scraper):
+    """Some pages embed ViewState in a script literal — regex catches it."""
+    html = '<script>var x = {javax.faces.ViewState"value="regex_token"};</script>'
+    out = scraper._extract_view_state(html)
+    assert out == "regex_token"
+
+
+def test_extract_view_state_returns_none_when_missing(scraper):
+    assert scraper._extract_view_state("<html></html>") is None
+    assert scraper._view_state is None
+
+
+def test_extract_view_state_skips_input_with_empty_value(scraper):
+    html = '<input name="javax.faces.ViewState" value=""/>'
+    assert scraper._extract_view_state(html) is None
+
+
+# ---------------------------------------------------------------------------
+# _initialize_search_page
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_search_page_returns_false_on_get_failure(scraper):
+    with patch.object(scraper, "_get", return_value=None):
+        assert scraper._initialize_search_page() is False
+
+
+def test_initialize_search_page_with_view_state(scraper):
+    fake_resp = MagicMock()
+    fake_resp.text = '<input name="javax.faces.ViewState" value="vs1"/>'
+    with patch.object(scraper, "_get", return_value=fake_resp):
+        assert scraper._initialize_search_page() is True
+    assert scraper._view_state == "vs1"
+
+
+def test_initialize_search_page_without_view_state_still_succeeds(scraper):
+    """When no ViewState is found, return True (page is plain HTML)."""
+    fake_resp = MagicMock()
+    fake_resp.text = "<html><body>no JSF</body></html>"
+    with patch.object(scraper, "_get", return_value=fake_resp):
+        assert scraper._initialize_search_page() is True
+
+
+# ---------------------------------------------------------------------------
+# _parse_sinec_results / _parse_sinec_plain_html / _parse_result_row
+# ---------------------------------------------------------------------------
+
+
+def test_parse_result_row_extracts_full_record(scraper):
+    html = """
+    <table><tbody>
+      <tr>
+        <td>NOM-001-SSA1-2010</td>
+        <td>Norma de equipo médico</td>
+        <td>SSA1</td>
+        <td>15/03/2010</td>
+        <td>Vigente</td>
+      </tr>
+    </tbody></table>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+    out = scraper._parse_result_row(row)
+    assert out is not None
+    assert out["nom_id"] == "NOM-001-SSA1-2010"
+    assert "equipo" in out["title"]
+    assert out["status"] == "vigente"
+    assert out["date_published"] == "2010-03-15"
+
+
+def test_parse_result_row_returns_none_when_no_nom_pattern(scraper):
+    html = "<tr><td>Not a NOM</td><td>Junk</td></tr>"
+    row = BeautifulSoup(html, "html.parser").find("tr")
+    assert scraper._parse_result_row(row) is None
+
+
+def test_parse_result_row_detects_cancelada_in_text(scraper):
+    html = """
+    <tr>
+      <td>NOM-002-SSA1-2015 (cancelada)</td>
+      <td>Old norm</td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+    out = scraper._parse_result_row(row)
+    assert out["status"] == "cancelada"
+
+
+def test_parse_result_row_extracts_dof_reference(scraper):
+    html = """
+    <tr>
+      <td>NOM-003-SE-2020 DOF: 15/03/2020</td>
+      <td>Title</td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+    out = scraper._parse_result_row(row)
+    assert "DOF" in out["dof_reference"]
+
+
+def test_parse_result_row_resolves_relative_url(scraper):
+    html = """
+    <tr>
+      <td><a href="/detalle/123">NOM-001-SSA1-2010</a></td>
+      <td>Title</td>
+    </tr>
+    """
+    row = BeautifulSoup(html, "html.parser").find("tr")
+    out = scraper._parse_result_row(row)
+    assert out["url"].startswith("https://sinec.gob.mx/")
+
+
+def test_parse_sinec_results_handles_jsf_cdata(scraper):
+    """JSF AJAX responses wrap HTML in <update><![CDATA[...]]>."""
+    html = """
+    <partial-response>
+      <changes>
+        <update><![CDATA[
+          <table><tbody>
+            <tr>
+              <td>NOM-007-SSA1-2010</td>
+              <td>Body of norm</td>
+            </tr>
+          </tbody></table>
+        ]]></update>
+      </changes>
+    </partial-response>
+    """
+    out = scraper._parse_sinec_results(html)
+    assert len(out) == 1
+    assert out[0]["nom_id"] == "NOM-007-SSA1-2010"
+
+
+def test_parse_sinec_results_handles_plain_html(scraper):
+    """When CDATA absent, parse the html directly."""
+    html = "<table><tbody><tr><td>NOM-008-SSA1-2015</td><td>X</td></tr></tbody></table>"
+    out = scraper._parse_sinec_results(html)
+    assert len(out) == 1
+
+
+def test_parse_sinec_plain_html_extracts_via_text_pattern(scraper):
+    html = """
+    <html><body>
+      <div class="result">NOM-009-SSA1-2020 — Some norm description (vigente) DOF 01/01/2020</div>
+    </body></html>
+    """
+    out = scraper._parse_sinec_plain_html(html)
+    assert len(out) >= 1
+    # Find the entry that matches our NOM
+    matching = [n for n in out if n["nom_id"] == "NOM-009-SSA1-2020"]
+    assert len(matching) >= 1
+    assert matching[0]["status"] == "vigente"
+
+
+def test_parse_sinec_plain_html_detects_cancelada(scraper):
+    html = '<div class="result">NOM-010-SSA1-2020 cancelada</div>'
+    out = scraper._parse_sinec_plain_html(html)
+    matching = [n for n in out if n["nom_id"] == "NOM-010-SSA1-2020"]
+    assert matching and matching[0]["status"] == "cancelada"
+
+
+def test_parse_sinec_plain_html_detects_proyecto(scraper):
+    html = '<div class="result">PROY-NOM-011-SSA1-2025 proyecto</div>'
+    out = scraper._parse_sinec_plain_html(html)
+    matching = [n for n in out if "011" in n["nom_id"]]
+    assert matching and matching[0]["status"] == "en_proyecto"
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint / save_results
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_checkpoint_round_trip(scraper, tmp_path):
+    noms = [
+        {"nom_id": "NOM-001-SSA1-2010", "title": "X"},
+        {"nom_id": "NOM-002-SSA1-2010", "title": "Y"},
+    ]
+    scraper.save_checkpoint(noms, tmp_path)
+    loaded = scraper.load_checkpoint(tmp_path)
+    assert loaded == noms
+
+
+def test_load_checkpoint_returns_empty_when_missing(scraper, tmp_path):
+    assert scraper.load_checkpoint(tmp_path / "nope") == []
+
+
+def test_load_checkpoint_returns_empty_on_invalid_json(scraper, tmp_path):
+    # Write a checkpoint file at the path the loader expects.
+    from apps.scraper.federal.sinec_scraper import _CHECKPOINT_FILENAME
+
+    (tmp_path / _CHECKPOINT_FILENAME).write_text("not json", encoding="utf-8")
+    assert scraper.load_checkpoint(tmp_path) == []
+
+
+def test_save_results_writes_json(tmp_path):
+    out = tmp_path / "out" / "result.json"
+    SinecScraper.save_results([{"nom_id": "NOM-001"}], out)
+    assert out.exists()
+    assert json.loads(out.read_text(encoding="utf-8")) == [{"nom_id": "NOM-001"}]


### PR DESCRIPTION
## Summary

A+ remediation: continued **WS1 Phase 1C** (three more 0% scrapers) + **WS1 Phase 1D** (backend gate ratchet) + **WS2 Phase 2B** (frontend gate ratchet).

### Backend coverage moves
| Module | Before | After | New tests |
|---|---:|---:|---:|
| \`apps/scraper/utils/law_registry.py\` | 0% | **71%** | 19 |
| \`apps/scraper/federal/sinec_scraper.py\` | 0% | **69%** | 44 |
| \`apps/scraper/municipal/pnt_scraper.py\` | 0% | **66%** | 56 |
| **Backend total** | 53% | **56%** | 119 |

CI gate ratcheted **48 → 51** with 5pp headroom over actual.

### Frontend gate ratchet (WS2 Phase 2B)
Observed floor unchanged (stmts 56.44 / branches 49.68 / funcs 52.09 / lines 57.66). Tightened gates from 5pp headroom to **3pp headroom** — heading toward the WS2 Phase 2C lock target of ≥50/40/50/50:
- statements: 51 → **53**
- branches: 44 → **46**
- functions: 47 → **49**
- lines: 52 → **54**

### Test coverage detail

**\`law_registry.py\`** — JSON file loader + reglamentos merge + filter methods + summary aggregation. Mutation-isolation tests verify \`all()\` and \`get_by_id()\` return copies.

**\`sinec_scraper.py\`** — Pure helpers (\`_normalize_text\`, agency abbreviations, date extraction), HTTP error matrix (\`_get\` + \`_post\` retry behavior, 4xx-non-429 short-circuit), ViewState extraction (input element + regex fallback), JSF CDATA + plain HTML parsing, status detection (vigente/cancelada/proyecto), checkpoint round-trip.

**\`pnt_scraper.py\`** — \`_sanitize_filename\`, regulatory keywords match, INEGI state validation, JSON API mocking (\`_api_post\` / \`_api_get\`), pagination with \`fetch_all_records\` (paginate-until-empty, stops-at-total, list-response), document URL/title/date extraction with nested-field fallback, municipality name cleaning (parametrized over PNT prefix patterns), full \`scrape_catalog\` orchestration with dedup-by-url + filter-misses paths.

## Test plan
- [x] pytest: 1885 passed, 17 skipped, 0 failures (+119 new tests)
- [x] Backend coverage: 53% → 56% (CI gate at 51% passes with 5pp headroom)
- [x] Frontend coverage gates pass (3pp headroom over observed floor)
- [x] black + isort: clean
- [x] \`audit_silent_excepts.py\`: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)