### PR TITLE
test(scraper): cover state_congress_municipal + scjn_playwright; ratchet backend 54 → 56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
       run: poetry run python scripts/utils/audit_silent_excepts.py
 
     - name: Run Pytest with coverage
-      # Coverage floor: ratcheted 44 → 48 → 51 → 54 as WS1 Phases 1A/1B/1C
+      # Coverage floor: ratcheted 44 → 48 → 51 → 54 → 56 as WS1 Phase 1C
       # closed scheduling, parser pipeline, scjn, treaty, playwright_base,
-      # law_registry, sinec, pnt, and 5 state scrapers (cdmx, edomex,
-      # michoacan, slp, zacatecas). Actual is ~59%. Next target: 60%.
-      run: poetry run pytest tests/ -v --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=54
+      # law_registry, sinec, pnt, 5 state scrapers, state_congress_municipal,
+      # and scjn_playwright partial coverage. Actual is ~61%. Target: 60%.
+      run: poetry run pytest tests/ -v --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=56
       env:
         PYTHONPATH: apps:.
 

--- a/tests/scraper/test_scjn_playwright_full.py
+++ b/tests/scraper/test_scjn_playwright_full.py
@@ -1,0 +1,405 @@
+"""Tests for ``apps.scraper.judicial.scjn_playwright``.
+
+Playwright is an optional dep — uses the same shim pattern as
+``test_playwright_base.py`` so the tests run when Playwright isn't
+installed. Targets the SJF-specific extraction logic by stubbing the
+Playwright element interface (query_selector / query_selector_all /
+inner_text / get_attribute / etc.).
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Playwright shim (same pattern as test_playwright_base.py)
+# ---------------------------------------------------------------------------
+
+if "playwright" not in sys.modules:
+    _pw = ModuleType("playwright")
+    _pw_sync = ModuleType("playwright.sync_api")
+
+    class _PlaywrightTimeoutError(Exception):
+        pass
+
+    _pw_sync.Browser = type("Browser", (), {})  # type: ignore[attr-defined]
+    _pw_sync.BrowserContext = type("BrowserContext", (), {})  # type: ignore[attr-defined]
+    _pw_sync.Page = type("Page", (), {})  # type: ignore[attr-defined]
+    _pw_sync.Playwright = type("Playwright", (), {})  # type: ignore[attr-defined]
+    _pw_sync.TimeoutError = _PlaywrightTimeoutError  # type: ignore[attr-defined]
+    _pw_sync.sync_playwright = MagicMock()  # type: ignore[attr-defined]
+
+    _pw.sync_api = _pw_sync  # type: ignore[attr-defined]
+    sys.modules["playwright"] = _pw
+    sys.modules["playwright.sync_api"] = _pw_sync
+
+
+# httpx is an optional dep used by MadfamBridge. Shim if missing.
+if "httpx" not in sys.modules:
+    _httpx = ModuleType("httpx")
+    _httpx.Client = MagicMock()  # type: ignore[attr-defined]
+    _httpx.AsyncClient = MagicMock()  # type: ignore[attr-defined]
+    _httpx.HTTPError = type("HTTPError", (Exception,), {})  # type: ignore[attr-defined]
+    _httpx.TimeoutException = type("TimeoutException", (Exception,), {})  # type: ignore[attr-defined]
+    sys.modules["httpx"] = _httpx
+
+
+from apps.scraper.judicial.scjn_playwright import (  # noqa: E402
+    SJF_BASE_URL,
+    SJF_DETAIL_URL,
+    ScjnPlaywrightScraper,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scraper(tmp_path):
+    """Build a scraper without invoking the bridge — patch where it would fire."""
+    with patch("apps.scraper.judicial.scjn_playwright.MadfamBridge"):
+        s = ScjnPlaywrightScraper(output_dir=str(tmp_path / "out"))
+    s._epoca = 10
+    s._tipo = "jurisprudencia"
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_constants_use_sjfsemanal_subdomain():
+    assert "sjfsemanal" in SJF_BASE_URL
+    assert "sjfsemanal" in SJF_DETAIL_URL
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+def test_init_inherits_playwright_base(scraper):
+    from apps.scraper.playwright_base import PlaywrightBase
+
+    assert isinstance(scraper, PlaywrightBase)
+
+
+def test_init_default_epoca_and_tipo(tmp_path):
+    with patch("apps.scraper.judicial.scjn_playwright.MadfamBridge"):
+        s = ScjnPlaywrightScraper(output_dir=str(tmp_path / "out"))
+    assert s._epoca == 10
+    assert s._tipo == "jurisprudencia"
+
+
+# ---------------------------------------------------------------------------
+# _make_record
+# ---------------------------------------------------------------------------
+
+
+def test_make_record_full_fields(scraper):
+    rec = scraper._make_record(
+        registro="2031846",
+        rubro="Some rubro",
+        texto="Body",
+        instancia="Pleno",
+        materia="Civil",
+        tesis_num="P./J. 1/2024",
+        url="https://custom/url",
+    )
+    assert rec["registro"] == "2031846"
+    assert rec["rubro"] == "Some rubro"
+    assert rec["instancia"] == "Pleno"
+    assert rec["url"] == "https://custom/url"
+    assert rec["tipo"] == "jurisprudencia"
+    assert rec["epoca"] == 10
+    assert rec["epoca_nombre"]  # populated from EPOCAS
+    assert rec["source"] == "sjf_scjn_playwright"
+
+
+def test_make_record_synthesizes_url_from_registro(scraper):
+    rec = scraper._make_record(registro="123456", rubro="Test")
+    assert "123456" in rec["url"]
+    assert "sjfsemanal" in rec["url"]
+
+
+def test_make_record_unknown_epoca_falls_back(scraper):
+    scraper._epoca = 99
+    rec = scraper._make_record(registro="1", rubro="X")
+    assert "99" in rec["epoca_nombre"]
+
+
+# ---------------------------------------------------------------------------
+# _extract_from_container
+# ---------------------------------------------------------------------------
+
+
+def _fake_element(text: str = "", attrs: dict | None = None) -> MagicMock:
+    """Build a mock playwright element returning *text* on inner_text()."""
+    el = MagicMock()
+    el.inner_text.return_value = text
+    el.get_attribute.side_effect = lambda key: (attrs or {}).get(key, "")
+    el.query_selector.return_value = None
+    el.query_selector_all.return_value = []
+    return el
+
+
+def test_extract_from_container_returns_none_short_rubro(scraper):
+    """Rubro shorter than 10 chars → return None."""
+    container = MagicMock()
+    container.query_selector.return_value = _fake_element("Short")
+    assert scraper._extract_from_container(container) is None
+
+
+def test_extract_from_container_returns_none_when_no_title(scraper):
+    container = MagicMock()
+    container.query_selector.return_value = None
+    assert scraper._extract_from_container(container) is None
+
+
+def test_extract_from_container_swallows_exception(scraper):
+    """A runtime error during extraction yields None, not an exception."""
+    container = MagicMock()
+    container.query_selector.side_effect = RuntimeError("boom")
+    assert scraper._extract_from_container(container) is None
+
+
+def test_extract_from_container_full_extraction(scraper):
+    """Happy path with all fields present."""
+    title_el = _fake_element("LONG ENOUGH RUBRO TEXT")
+    text_el = _fake_element("Body content here")
+    link_el = _fake_element("", attrs={"href": "/detalle/tesis/2031846"})
+
+    container = MagicMock()
+
+    def _selector_dispatch(selector):
+        if "h2" in selector or "rubro" in selector:
+            return title_el
+        if "texto" in selector or "contenido" in selector:
+            return text_el
+        if "a[href]" in selector:
+            return link_el
+        return None
+
+    container.query_selector.side_effect = _selector_dispatch
+    # _extract_label uses query_selector + query_selector_all on container
+    container.query_selector_all.return_value = []
+
+    rec = scraper._extract_from_container(container)
+    assert rec is not None
+    assert rec["registro"] == "2031846"
+    assert "RUBRO" in rec["rubro"]
+    assert rec["texto"] == "Body content here"
+
+
+# ---------------------------------------------------------------------------
+# _extract_from_table_row
+# ---------------------------------------------------------------------------
+
+
+def test_extract_from_table_row_too_few_cells(scraper):
+    row = MagicMock()
+    row.query_selector_all.return_value = [_fake_element("only")]
+    assert scraper._extract_from_table_row(row) is None
+
+
+def test_extract_from_table_row_short_rubro(scraper):
+    row = MagicMock()
+    row.query_selector_all.return_value = [_fake_element("X"), _fake_element("more")]
+    assert scraper._extract_from_table_row(row) is None
+
+
+def test_extract_from_table_row_extracts_all_cells(scraper):
+    cells = [
+        _fake_element("LONG RUBRO TEXT FOR EXTRACTION"),
+        _fake_element("Pleno"),
+        _fake_element("Civil"),
+        _fake_element("P./J. 1/2024"),
+        _fake_element("Body text"),
+    ]
+    row = MagicMock()
+    row.query_selector_all.return_value = cells
+    row.query_selector.return_value = _fake_element(
+        "", attrs={"href": "/detalle/tesis/777"}
+    )
+    rec = scraper._extract_from_table_row(row)
+    assert rec is not None
+    assert rec["registro"] == "777"
+    assert rec["instancia"] == "Pleno"
+    assert rec["materia"] == "Civil"
+    assert rec["tesis_num"] == "P./J. 1/2024"
+    assert rec["texto"] == "Body text"
+
+
+def test_extract_from_table_row_swallows_exception(scraper):
+    row = MagicMock()
+    row.query_selector_all.side_effect = RuntimeError("boom")
+    assert scraper._extract_from_table_row(row) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_from_dl
+# ---------------------------------------------------------------------------
+
+
+def test_extract_from_dl_returns_none_when_no_rubro(scraper):
+    dl = MagicMock()
+    dl.query_selector_all.side_effect = [
+        [_fake_element("Otro:")],
+        [_fake_element("value")],
+    ]
+    assert scraper._extract_from_dl(dl) is None
+
+
+def test_extract_from_dl_extracts_full_record(scraper):
+    dts = [
+        _fake_element("Rubro:"),
+        _fake_element("Registro:"),
+        _fake_element("Instancia:"),
+    ]
+    dds = [
+        _fake_element("The rubro text"),
+        _fake_element("999888"),
+        _fake_element("Pleno"),
+    ]
+    dl = MagicMock()
+    dl.query_selector_all.side_effect = [dts, dds]
+    rec = scraper._extract_from_dl(dl)
+    assert rec is not None
+    assert rec["rubro"] == "The rubro text"
+    assert rec["registro"] == "999888"
+    assert rec["instancia"] == "Pleno"
+    assert "999888" in rec["url"]
+
+
+def test_extract_from_dl_swallows_exception(scraper):
+    dl = MagicMock()
+    dl.query_selector_all.side_effect = RuntimeError("boom")
+    assert scraper._extract_from_dl(dl) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_label
+# ---------------------------------------------------------------------------
+
+
+def test_extract_label_via_class_match(scraper):
+    container = MagicMock()
+    container.query_selector.return_value = _fake_element("Civil")
+    assert scraper._extract_label(container, "materia") == "Civil"
+
+
+def test_extract_label_returns_empty_when_no_match(scraper):
+    container = MagicMock()
+    container.query_selector.return_value = None
+    container.query_selector_all.return_value = []
+    assert scraper._extract_label(container, "materia") == ""
+
+
+def test_extract_label_swallows_exception(scraper):
+    container = MagicMock()
+    container.query_selector.side_effect = RuntimeError("boom")
+    assert scraper._extract_label(container, "materia") == ""
+
+
+# ---------------------------------------------------------------------------
+# _enrich_records — short-circuits when records already populated
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_records_skips_records_with_existing_texto(scraper):
+    records = [
+        {"registro": "1", "rubro": "X", "texto": "Already filled"},
+        {"registro": "2", "rubro": "Y", "texto": "Also filled"},
+    ]
+    out = scraper._enrich_records(records)
+    assert len(out) == 2
+    # Untouched
+    assert out[0]["texto"] == "Already filled"
+
+
+# ---------------------------------------------------------------------------
+# _parse_page — strategy waterfall
+# ---------------------------------------------------------------------------
+
+
+def test_parse_page_returns_empty_without_page(scraper):
+    scraper._page = None
+    assert scraper._parse_page() == []
+
+
+def test_parse_page_strategy_1_containers(scraper):
+    """When containers yield records, the table/dl strategies are skipped."""
+    fake_page = MagicMock()
+    container = MagicMock()
+    title_el = _fake_element("Some sufficiently long rubro text")
+    text_el = _fake_element("Body content")
+    link_el = _fake_element("", attrs={"href": "/detalle/tesis/111"})
+
+    def _container_dispatch(selector):
+        if "h2" in selector or "rubro" in selector:
+            return title_el
+        if "texto" in selector or "contenido" in selector:
+            return text_el
+        if "a[href]" in selector:
+            return link_el
+        return None
+
+    container.query_selector.side_effect = _container_dispatch
+    container.query_selector_all.return_value = []
+
+    def _page_query_all(selector):
+        if "resultado" in selector or "tesis-item" in selector or "article" in selector:
+            return [container]
+        return []
+
+    fake_page.query_selector_all.side_effect = _page_query_all
+    scraper._page = fake_page
+
+    items = scraper._parse_page()
+    assert len(items) == 1
+    assert items[0]["registro"] == "111"
+
+
+def test_parse_page_strategy_4_link_fallback(scraper):
+    """When all earlier strategies yield nothing, fall back to tesis links."""
+    fake_page = MagicMock()
+    long_text_link = _fake_element(
+        "A very long tesis link text that survives the >20 chars check",
+        attrs={"href": "/detalle/tesis/2031846"},
+    )
+
+    def _page_query_all(selector):
+        # Strategies 1-3 return nothing
+        if "tesis" in selector and "href" in selector:
+            return [long_text_link]
+        return []
+
+    fake_page.query_selector_all.side_effect = _page_query_all
+    scraper._page = fake_page
+
+    items = scraper._parse_page()
+    assert len(items) == 1
+    assert items[0]["registro"] == "2031846"
+
+
+def test_parse_page_skips_short_link_text(scraper):
+    """Links with text <= 20 chars are skipped."""
+    fake_page = MagicMock()
+    short_link = _fake_element("Short", attrs={"href": "/x/1"})
+
+    def _page_query_all(selector):
+        if "tesis" in selector and "href" in selector:
+            return [short_link]
+        return []
+
+    fake_page.query_selector_all.side_effect = _page_query_all
+    scraper._page = fake_page
+
+    items = scraper._parse_page()
+    assert items == []

--- a/tests/scraper/test_state_congress_municipal.py
+++ b/tests/scraper/test_state_congress_municipal.py
@@ -1,0 +1,309 @@
+"""Tests for ``apps.scraper.municipal.state_congress_municipal``.
+
+This scraper navigates state congress portals to discover municipal
+income laws (leyes de ingresos municipales). Tests stub ``fetch_page``
+at the boundary so we never hit the live portals.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from apps.scraper.municipal.state_congress_municipal import (
+    STATE_CONGRESS_REGISTRY,
+    StateCongressMunicipalScraper,
+    get_portal_info,
+    list_supported_states,
+    scrape_state,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def test_list_supported_states_returns_sorted():
+    out = list_supported_states()
+    assert "jalisco" in out
+    assert out == sorted(out)
+
+
+def test_get_portal_info_known_state():
+    info = get_portal_info("jalisco")
+    assert info["state"] == "Jalisco"
+    assert info["base_url"].startswith("https://")
+
+
+def test_get_portal_info_unknown_state_raises():
+    with pytest.raises(ValueError, match="Unknown state"):
+        get_portal_info("not_a_state")
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state_id", list(STATE_CONGRESS_REGISTRY.keys()))
+def test_init_succeeds_for_each_registered_state(state_id):
+    s = StateCongressMunicipalScraper(state_id=state_id)
+    assert s.state_id == state_id
+    assert s.portal["state"] == STATE_CONGRESS_REGISTRY[state_id]["state"]
+
+
+def test_init_raises_for_unknown_state():
+    with pytest.raises(ValueError, match="Unknown state"):
+        StateCongressMunicipalScraper(state_id="not_a_state")
+
+
+def test_init_respects_max_results():
+    s = StateCongressMunicipalScraper(state_id="jalisco", max_results=10)
+    assert s.max_results == 10
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scraper():
+    """Build a Jalisco scraper for instance-method tests."""
+    return StateCongressMunicipalScraper(state_id="jalisco")
+
+
+# ---------------------------------------------------------------------------
+# _is_municipal_law_link
+# ---------------------------------------------------------------------------
+
+
+def test_is_municipal_law_link_matches_keyword(scraper):
+    """Texts matching `keywords` regex should be flagged as municipal laws."""
+    assert (
+        scraper._is_municipal_law_link(
+            "Ley de Ingresos del Municipio de Guadalajara 2024",
+            "/leyesmunicipales/guadalajara.pdf",
+        )
+        is True
+    )
+
+
+def test_is_municipal_law_link_excludes_state_law(scraper):
+    """`exclude` regex should disqualify state-level laws."""
+    assert scraper._is_municipal_law_link("Constitución Política", "/foo.pdf") is False
+
+
+def test_is_municipal_law_link_rejects_unrelated(scraper):
+    """Texts that don't match `keywords` are skipped."""
+    assert scraper._is_municipal_law_link("Some random document", "/x.pdf") is False
+
+
+# ---------------------------------------------------------------------------
+# _extract_municipality
+# ---------------------------------------------------------------------------
+
+
+def test_extract_municipality_from_title(scraper):
+    out = scraper._extract_municipality(
+        "Ley de Ingresos del Municipio de Guadalajara 2024",
+        "https://example.com/x.pdf",
+    )
+    assert "Guadalajara" in out
+
+
+def test_extract_municipality_falls_back_to_state(scraper):
+    """When no municipality phrase + no extractable URL segments, returns the state name."""
+    # URL with only generic segments (excluded by the path-extraction logic):
+    # "ley", "decreto", "doc", "archivo", "pdf" are all explicitly skipped.
+    out = scraper._extract_municipality(
+        "Ley de Ingresos 2024", "https://example.com/ley/decreto/archivo.pdf"
+    )
+    assert out == scraper.portal["state"]
+
+
+def test_extract_municipality_via_url_path(scraper):
+    """Path-based extraction looks for proper-noun-ish segments."""
+    out = scraper._extract_municipality(
+        "Ley", "https://example.com/leyes/zapopan/2024.pdf"
+    )
+    # Either matched zapopan from URL or fell back to state — both acceptable
+    assert isinstance(out, str) and len(out) > 0
+
+
+# ---------------------------------------------------------------------------
+# _extract_fiscal_year
+# ---------------------------------------------------------------------------
+
+
+def test_extract_fiscal_year_from_title(scraper):
+    assert scraper._extract_fiscal_year("Ley de Ingresos 2024", "x") == "2024"
+
+
+def test_extract_fiscal_year_from_url(scraper):
+    assert (
+        scraper._extract_fiscal_year("Ley", "https://example.com/2023/file.pdf")
+        == "2023"
+    )
+
+
+def test_extract_fiscal_year_returns_none_when_missing(scraper):
+    assert scraper._extract_fiscal_year("Ley sin año", "https://x.com/y.pdf") is None
+
+
+# ---------------------------------------------------------------------------
+# _classify_document
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        ("Ley de Ingresos del Municipio", "Ley de Ingresos"),
+        ("Presupuesto de Egresos 2024", "Presupuesto de Egresos"),
+        ("Ley de Hacienda Municipal", "Ley de Hacienda Municipal"),
+        ("Tabla de Valores Catastrales", "Tabla de Valores"),
+    ],
+)
+def test_classify_document_known_categories(scraper, title, expected):
+    assert scraper._classify_document(title) == expected
+
+
+def test_classify_document_falls_through_to_extract_category(scraper):
+    """Unknown titles delegate to the parent's extract_category."""
+    out = scraper._classify_document("Otro Documento")
+    # Just verify it returns a string — the parent's extract_category is the
+    # source of truth for this fallback path.
+    assert isinstance(out, str)
+
+
+# ---------------------------------------------------------------------------
+# _build_law_entry
+# ---------------------------------------------------------------------------
+
+
+def test_build_law_entry_full_shape(scraper):
+    entry = scraper._build_law_entry(
+        "Ley de Ingresos del Municipio de Guadalajara 2024",
+        "https://example.com/guadalajara.pdf",
+    )
+    assert entry["name"]  # title set
+    assert entry["url"] == "https://example.com/guadalajara.pdf"
+    assert "Guadalajara" in entry["municipality"]
+    assert entry["state"] == "Jalisco"
+    assert entry["tier"] == "municipal"
+    assert entry["status"] == "Discovered"
+    assert entry["source"] == "state_congress"
+    assert entry["fiscal_year"] == "2024"
+
+
+def test_build_law_entry_collapses_whitespace(scraper):
+    entry = scraper._build_law_entry(
+        "Ley   de\n\tIngresos",
+        "https://example.com/x.pdf",
+    )
+    assert entry["name"] == "Ley de Ingresos"
+
+
+def test_build_law_entry_omits_fiscal_year_when_missing(scraper):
+    entry = scraper._build_law_entry("Ley sin año", "https://example.com/x.pdf")
+    assert "fiscal_year" not in entry
+
+
+# ---------------------------------------------------------------------------
+# _title_from_url
+# ---------------------------------------------------------------------------
+
+
+def test_title_from_url_parses_filename(scraper):
+    out = scraper._title_from_url("https://example.com/path/Ley_de_Ingresos_2024.pdf")
+    assert "Ley de Ingresos 2024" in out
+
+
+def test_title_from_url_handles_url_encoded_filename(scraper):
+    out = scraper._title_from_url("https://example.com/Ley%20de%20Ingresos.pdf")
+    assert "Ley" in out and "Ingresos" in out
+
+
+# ---------------------------------------------------------------------------
+# scrape_law_content — passthrough to download_law_content
+# ---------------------------------------------------------------------------
+
+
+def test_scrape_law_content_default_output_dir(scraper):
+    with patch.object(scraper, "download_law_content") as mock_dl:
+        mock_dl.return_value = {"file_path": "out.pdf"}
+        result = scraper.scrape_law_content("https://example.com/x.pdf")
+    assert result == {"file_path": "out.pdf"}
+    called_dir = mock_dl.call_args.args[1]
+    assert called_dir == "data/municipal/jalisco/congress"
+
+
+def test_scrape_law_content_explicit_output_dir(scraper):
+    with patch.object(scraper, "download_law_content") as mock_dl:
+        mock_dl.return_value = None
+        scraper.scrape_law_content("https://example.com/x.pdf", output_dir="/tmp/out")
+    assert mock_dl.call_args.args[1] == "/tmp/out"
+
+
+# ---------------------------------------------------------------------------
+# scrape_catalog (high-level)
+# ---------------------------------------------------------------------------
+
+
+def test_scrape_catalog_returns_empty_on_unreachable(scraper):
+    """All fetch_page calls returning None → empty list, no exception."""
+    with patch.object(scraper, "fetch_page", return_value=None):
+        result = scraper.scrape_catalog()
+    assert result == []
+
+
+def test_scrape_catalog_respects_max_results(scraper):
+    """When max_results is set, the result is truncated."""
+    scraper.max_results = 2
+    fake_laws = [{"url": f"u{i}", "name": f"law{i}"} for i in range(10)]
+    with patch.object(scraper, "_scrape_paginated_catalog", return_value=fake_laws):
+        result = scraper.scrape_catalog()
+    assert len(result) == 2
+
+
+def test_scrape_catalog_non_paginated_state(scraper):
+    """A state without pagination calls _scrape_catalog_page once."""
+    s = StateCongressMunicipalScraper(state_id="nuevo_leon")  # pagination=None
+    fake_laws = [{"url": "u1", "name": "law1"}]
+    with patch.object(s, "_scrape_catalog_page", return_value=fake_laws) as mock_page:
+        result = s.scrape_catalog()
+    assert result == fake_laws
+    mock_page.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# scrape_state convenience function
+# ---------------------------------------------------------------------------
+
+
+def test_scrape_state_invokes_scraper():
+    """The convenience function should construct + call scrape_catalog."""
+    fake_laws = [{"url": "u1"}]
+    with patch.object(
+        StateCongressMunicipalScraper, "scrape_catalog", return_value=fake_laws
+    ):
+        result = scrape_state("jalisco", max_results=5)
+    assert result == fake_laws
+
+
+# ---------------------------------------------------------------------------
+# _find_container — picks the configured selector
+# ---------------------------------------------------------------------------
+
+
+def test_find_container_returns_body_when_no_match(scraper):
+    """If no configured selector matches, fall back to <body>."""
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup("<html><body><p>nothing</p></body></html>", "html.parser")
+    container = scraper._find_container(soup)
+    assert container is not None
+    # Either body or top-level — just ensure we got something valid
+    assert container.name in {"body", "[document]", "html"} or container is soup


### PR DESCRIPTION
## Summary

A+ remediation: continued **WS1 Phase 1C** (two more 0% scrapers) + **WS1 Phase 1D** (gate ratchet 54 → 56).

### Coverage moves
| Module | Before | After | New tests |
|---|---:|---:|---:|
| \`apps/scraper/municipal/state_congress_municipal.py\` | 0% | **55%** | 36 |
| \`apps/scraper/judicial/scjn_playwright.py\` | 0% | **36%** | 25 |
| **Backend total** | 59% | **61%** | 61 |

CI gate ratcheted **54 → 56** (4.6pp headroom over 61% actual).

### Notes on \`scjn_playwright\` 36% partial coverage
The file is 428 statements; the bulk of remaining uncovered lines are in \`scrape_catalog\`, \`run\`, \`run_enrich_only\`, and \`main\` — these all require extensive Playwright \`Page\` mocking to drive the imperative browser-control flow. The 36% covers all the pure logic and DOM-extraction helpers (\`_make_record\`, \`_extract_from_container\` / \`_table_row\` / \`_dl\` / \`_label\`, \`_enrich_records\` short-circuit, \`_parse_page\` strategy waterfall). Pushing past 50% would mean fixture-heavy mocks that mostly verify the mock setup, not real behavior — better to leave that gap until a true integration test runs against a recorded SJF response.

### Cross-cutting: dual-shim pattern
The new \`test_scjn_playwright_full.py\` shims both \`playwright.sync_api\` AND \`httpx\` (used by \`MadfamBridge\`) so the module imports cleanly without either optional dep. Same callable-vs-MagicMock check in upstream test files protects against shim leakage.

## Test plan
- [x] pytest: 1991 passed, 17 skipped, 0 failures (+61 new tests)
- [x] Backend coverage: 59% → 61% (CI gate at 56% passes with 4.6pp headroom)
- [x] black + isort: clean
- [x] \`audit_silent_excepts.py\`: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)