### PR TITLE
docs(a+): progress snapshot + 6-workstream forward plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,19 @@ npm run lint:admin
 npm run lint:all
 ```
 
+### Quality audits (CI-enforced)
+
+```bash
+# Block silent bare-except blocks (`except Exception: pass` etc.)
+poetry run python scripts/utils/audit_silent_excepts.py
+
+# Block files >800 LOC (with explicit allowlist for known mega-scrapers)
+poetry run python scripts/utils/audit_file_sizes.py
+
+# Capture a TLS fingerprint for a host (for HOST_FINGERPRINTS pinning)
+poetry run python scripts/utils/capture_tls_fingerprint.py <host>
+```
+
 ### Build
 
 ```bash
@@ -505,6 +518,10 @@ type Lang = 'es' | 'en' | 'nah';
 | `scripts/scraping/wayback_bulk_recovery.py` | CDX API bulk mining for dead legal domains |
 | `scripts/scraping/dof_historical_scan.py` | DOF 2000-2026 scan for gap-filling + NOM detection + checkpointing + cross-reference |
 | `scripts/scraping/probe_datos_gob.py` | datos.gob.mx CKAN API probe, resource download, and legal relevance assessment |
+| `scripts/utils/audit_silent_excepts.py` | AST-based scanner that fails CI on `except Exception: pass`-style swallows missing `# noqa: BLE001` |
+| `scripts/utils/audit_file_sizes.py` | File-size audit with allowlist; fails CI on files >800 LOC outside the allowlist |
+| `scripts/utils/capture_tls_fingerprint.py` | Captures leaf-cert SHA-256 fingerprint for `HOST_FINGERPRINTS` pinning |
+| `apps/scraper/http.py` | Two-layer TLS trust: `HOST_FINGERPRINTS` (pinned) + `INSECURE_HOSTS` (verify=False fallback). `_FingerprintPinnedAdapter` validates leaf cert via urllib3 `assert_fingerprint`. |
 | `apps/api/search_views.py` | Full-text search with function_score recency boost, phrase matching, zero-result rescue |
 | `apps/api/admin_views.py` | Admin endpoints: metrics, jobs, config, pipeline, coverage, quarantine, task-health |
 | `apps/web/components/JsonLd.tsx` | Shared JSON-LD structured data component (used across 10+ pages) |
@@ -569,6 +586,22 @@ type Lang = 'es' | 'en' | 'nah';
 - WeasyPrint and other optional deps are similarly skipped in CI
 - Docker Compose services have resource limits (cpu/memory) to prevent runaway containers
 
+### Quality gates (PR-blocking)
+
+These gates run as discrete CI steps and fail the merge on regression:
+
+| Gate | Threshold | Source |
+|---|---|---|
+| Backend coverage | `--cov-fail-under=56` (actual ~61%) | `.github/workflows/ci.yml` |
+| Frontend coverage (`all: true`) | stmts 53 / branches 46 / funcs 49 / lines 54 (floor−3pp) | `apps/web/vitest.config.mts` |
+| Silent bare-except | 0 findings | `scripts/utils/audit_silent_excepts.py` |
+| File size | 0 files >800 LOC outside allowlist | `scripts/utils/audit_file_sizes.py` |
+| pip-audit | 0 high-severity CVEs in locked deps | CI step |
+| npm audit | 0 high-severity CVEs (`--audit-level=high`) | CI step |
+| CodeQL | 0 new alerts on PR | weekly + on-push |
+
+Backend coverage gate has been ratcheted 44 → 48 → 51 → 54 → 56 across PRs #56, #77–80. Next target: 60% per `docs/strategy/A_PLUS_PROGRESS_2026-04-27.md` WS-R1.
+
 ## Strategy Documentation
 
 `docs/strategy/` is the authoritative home for product/architectural strategy. Read these before assuming a feature priority. Index: [`docs/strategy/INDEX.md`](docs/strategy/INDEX.md).
@@ -583,9 +616,13 @@ type Lang = 'es' | 'en' | 'nah';
 | `SELVA_ONBOARDING_TICKET_2026-04-27.md` | Operator-side spec for provisioning the Selva relay client (unblocks `CHAT_BACKEND=selva`) |
 | `CNPG_MIGRATION_PREP_2026-04-27.md` | Tezca-side connection-pool prep + cutover runbook (gated on RFC 0012 cluster) |
 | `DOCKET_WATCHER_BOOTSTRAP_2026-04-27.md` | Bootstrap kit for the `madfam-org/docket-watcher` sibling repo (Q1-2027) |
+| `A_PLUS_REMEDIATION_PLAN_2026-04-27.md` | Original 8-workstream A+ plan + rubric (still authoritative on dimensions) |
+| `A_PLUS_PROGRESS_2026-04-27.md` | **Live A+ progress + forward plan.** Tracks PRs #55–80 (44%→61% backend coverage, 0 silent excepts, TLS pinning architecture). 6 remaining workstreams (WS-R1…WS-R6) with sequencing |
 | `partnerships/` | Partner-specific integration agreements |
 
 **Tracks shipped 2026-04-27 (PRs #46–52):** RMF scraper, `/preguntar` chat scaffold, state scrapers Wave 1A (4 states), `/cuenta/billing` scaffold, Karafiel audit doc, CNPG settings prep, docket-watcher spec, Selva onboarding ticket spec.
+
+**A+ remediation shipped 2026-04-27 (PRs #55, #56, #75–80):** backend coverage 44%→61%, 0 silent bare-except, 0 files >800 LOC, TLS fingerprint pinning architecture, frontend `vitest all:true` gates, silent-except CI gate, file-size CI gate, CVE SLO + Dependabot, scraper first-run checklist. Composite grade B+/B → **B+/A−**. Remaining work in `A_PLUS_PROGRESS_2026-04-27.md`.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All numbers sourced from `data/universe_registry.json` with links to official so
 - ✅ **Version History** - Track legal evolution over time
 - ✅ **REST API** - Machine-readable access for legal tech (paginated, filtered, rate-limited)
 - ✅ **Batch Processing** - Parallel ingestion with 4-8 workers
-- ✅ **Production Ready** - Full-stack testing (223 web Vitest + 76 admin Vitest + 493 Pytest)
+- ✅ **Production Ready** - Full-stack testing (1991+ Pytest + 761 web Vitest + 82 admin Vitest); backend coverage ≥61%, frontend with `all: true` denominator
 - ✅ **OpenAPI Documentation** - Swagger UI, ReDoc at `/api/docs/`
 - ✅ **Background Processing** - Celery + Redis for ingestion jobs
 - ✅ **Cross-References** - Automatic detection and linking between laws

--- a/docs/strategy/A_PLUS_PROGRESS_2026-04-27.md
+++ b/docs/strategy/A_PLUS_PROGRESS_2026-04-27.md
@@ -1,0 +1,187 @@
+# Tezca A+ Remediation — Progress & Forward Plan
+
+**Date:** 2026-04-27 (live snapshot)
+**Companion:** [`A_PLUS_REMEDIATION_PLAN_2026-04-27.md`](./A_PLUS_REMEDIATION_PLAN_2026-04-27.md) (original rubric, sequencing, open questions)
+**Status:** Active — this doc tracks the *delta* against the plan and re-sequences the remaining work.
+
+---
+
+## 1. Where we are vs. the A+ rubric
+
+| Dimension | Then (2026-04-27 baseline) | Now (post-PR-#80) | A+ threshold | Status |
+|---|---|---|---|:-:|
+| Test discipline (pass rate) | A — 1527/1542 = 99.0%, 15 skipped | A — 1991 passed / 17 skipped / 0 failures | A+ (≥99.5%, all skipped tracked) | 🟡 |
+| Backend coverage | C+ (44%, gate 44%) | **B+ (61% actual, 56% gate)** | A (≥60%, gate ≥55%) | ✅ |
+| Frontend coverage (`all: true`) | unknown — gate disabled | **B (gates 53/46/49/54, floor 56/50/52/58)** | A (≥50% statements w/ `all: true`) | ✅ |
+| Architectural integrity | A | A — 0 policy regressions in 90 days | A+ (90 days) | 🟢 |
+| Code-debt hygiene | A− (64 bare `except`, 7 files >900 LOC) | **A (0 silent excepts, 0 files >800 LOC)** | A+ (0 bare, ≤1 over 800 LOC) | 🟢 |
+| Infra resilience | C− | C− — RFC 0012 in flight, ES + Redis HA pending | A (multi-AZ PG/ES/Redis) | 🔴 |
+| Production-path validation | B− | B — per-scraper checklist landed; synthetic monitoring pending | A (live ≤7d, monitored) | 🟡 |
+| Security posture | A− | **A (TLS pinning architecture + CVE SLO)** — capture sweep pending | A (ISO 27001 prep started) | 🟡 |
+| Observability | B (Sentry + PostHog) | B (no change) | A (Grafana + SLO board) | 🔴 |
+
+**Composite right now: ~B+/A−.** Up from B+/B at the start. Everything that the application code itself can fix has been pushed near A. The **two open A− → A blockers are platform-side (HA + observability)**, plus one operator-side **(TLS fingerprint capture sweep + ISO 27001 prep)**.
+
+---
+
+## 2. What shipped — PRs #55 → #80
+
+Twelve PRs landed, ratcheting backend coverage 44% → 61% and frontend gates from disabled → 53/46/49/54.
+
+| PR | Workstream | Coverage move | Notes |
+|---|---|---|---|
+| #55 | WS1 Phase 1A | `scheduling/tasks.py` 0% → 73% | Celery beat tasks |
+| #56 | WS3 + WS4 + WS5 + WS6 | bare-except cleanup, vitest `all:true` flip, CVE SLO + Dependabot, scraper checklist | Bundled Items 2–5 |
+| #75 | WS3 enforcement + WS7 H7 | Silent-except CI gate; TLS fingerprint pinning architecture | `audit_silent_excepts.py` + `_FingerprintPinnedAdapter` + capture script |
+| #76 | WS1 Phase 1B | `parsers/pipeline.py` 0% → 76% | 35 tests, fixture-based |
+| #77 | WS1 Phase 1C/1D | `playwright_base` 0→96, `scjn_scraper` 22→71, `treaty_scraper` 14→59 | Gate 44 → 48 |
+| #78 | WS1 1C + WS2 2B | `law_registry` 0→71, `sinec_scraper` 0→69, `pnt_scraper` 0→66 | Backend gate 48 → 51, frontend gates ratcheted to 51/44/47/52 |
+| #79 | WS1 1C/1D | 5 state scrapers 0% → 60-70% | Gate 51 → 54 |
+| #80 | WS1 1C/1D | `state_congress_municipal` 0→55, `scjn_playwright` 0→36 | Gate 54 → 56 |
+
+**Test count:** 1527 → 1991 (+464). **Files >900 LOC:** 7 → 0. **Silent bare-except:** 64 → 0. **CI quality gates added:** 2 (silent-except audit + frontend `all: true` coverage).
+
+---
+
+## 3. What remains — six concrete workstreams
+
+The eight workstreams in the original plan collapse to six now that WS1 Phase 1A/1B/1C/1D, WS2 2A, WS3, WS4 (file-size threshold), WS5 partial, WS6 Phase 1, and WS7 H7-architecture are done.
+
+### WS-R1 — Backend coverage to 65% (push)
+**Effort:** ~3–5 days. **Owner:** engineering. **Leverage:** medium (incremental).
+
+The remaining 0% modules are mostly low-leverage (management commands wrapping already-tested logic). Best ROI: push `nom_scraper.py` (currently 14% — see coverage report), `conamer_scraper.py` (25%), and a few small management commands.
+
+**Concrete targets:**
+- `apps/scraper/federal/nom_scraper.py` (697 stmts, ~14%) → 50%
+- `apps/scraper/federal/conamer_scraper.py` (285 stmts, 25%) → 50%
+- `apps/api/management/commands/{ingest_rmf, classify_law_domains, backfill_cross_references, verify_dof_health}` (~250 stmts combined, all 0%) → 60%+ via golden-fixture invocation tests
+- `apps/scraper/federal/dof_daily.py` (214 stmts, 20%) → 50%
+
+**Done criterion:** backend coverage ≥65%, gate ratcheted to **60** with 5pp headroom.
+
+### WS-R2 — Frontend coverage ratchet to lock target (≥50/40/50/50)
+**Effort:** ~1–2 weeks. **Owner:** engineering. **Leverage:** medium.
+
+Current floor 56.44/49.68/52.09/57.66 with gates at 53/46/49/54 (3pp headroom). The lock target from the plan is ≥50/40/50/50, which we already exceed. The real next move: **raise the floor itself** via component-test backfill, then lock thresholds at floor−2pp.
+
+**Concrete targets:**
+- Audit `apps/web/components/` for components without tests; add 15–20 component tests bringing floor toward 65/55/60/65.
+- After floor reaches ≥65%, lock thresholds at 60/50/55/60 and document the lock in `apps/web/vitest.config.mts`.
+
+**Done criterion:** frontend coverage ≥65% statements / ≥55% branches; gates locked at floor−2pp; CI fails any PR that drops by >2pp.
+
+### WS-R3 — Operator security sweep (TLS fingerprint capture + ISO 27001 prep)
+**Effort:** ~1 day operator + 2 weeks ISO doc work. **Owner:** operator + security-track lead.
+
+The TLS pinning **architecture** landed in PR #75. The capture sweep is operator work:
+
+1. **Capture sweep (~1 day):** run `scripts/utils/capture_tls_fingerprint.py <host>` for each of the 10 hosts in `INSECURE_HOSTS`. For each successful capture, paste into `HOST_FINGERPRINTS` and remove from `INSECURE_HOSTS`. The current 10 hosts are listed in `apps/scraper/http.py:INSECURE_HOSTS`.
+
+2. **ISO 27001 audit RFC (~2 weeks):** file `internal-devops/audits/2026-Q3-iso27001-prep.md` per the original plan. Document encryption-at-rest (CNPG once cutover lands), access logs (already in `dataops.AcquisitionLog`), pen-test cadence (annual, operator-procured).
+
+**Done criterion:** ≥7 of 10 `INSECURE_HOSTS` hosts pinned; CLAUDE.md "Known Issues" promotes H7 to Resolved; ISO 27001 RFC filed.
+
+### WS-R4 — Synthetic monitoring + Karafiel-test integration runtime
+**Effort:** ~1–2 weeks. **Owner:** engineering + ops + Karafiel team.
+
+Per the original WS6 Phase 2/3:
+
+1. **Synthetic probes (~1 week):** new `tests/synthetic/` directory with health-checks against `api.tezca.mx/api/v1/admin/health/`, `/api/v1/stats/`, `/api/v1/laws/cpeum/`. Run on a 5-minute Grafana cadence; PagerDuty alert on probe failure.
+
+2. **Karafiel-test integration (~1 week):** per `KARAFIEL_INTEGRATION_AUDIT_2026-04-27.md` §7. Provision API key, register webhook with `domain_filter: ["fiscal"]`, fire test event, verify end-to-end.
+
+**Done criterion:** every Wave 1A scraper has at least one production AcquisitionLog row; synthetic probes deployed + alerting; Karafiel-test integration runtime passes.
+
+### WS-R5 — Infra HA (PG + ES + Redis)
+**Effort:** ~6–8 weeks. **Owner:** platform team. **Leverage:** highest on resilience axis.
+
+Tezca-side prep is **already done** (PR #52 added CNPG-friendly DB connection settings). Remaining is platform-side:
+
+1. **Postgres HA (CNPG)** — RFC 0012, in flight per `CNPG_MIGRATION_PREP_2026-04-27.md`. Tezca cutover is a one-line env var swap.
+2. **ES HA via ECK** — file new RFC `0015-elasticsearch-ha-via-eck.md`. Tezca-side: `apps/api/config.py` already supports comma-split ES_HOST.
+3. **Redis HA via Sentinel** — staged manifests in `enclii/infra/k8s/redis-sentinel/`. Tezca-side: env-var swap `REDIS_URL` → `redis-sentinel://...`.
+
+**Done criterion:** all three failover drills pass quarterly; status page publishes 99.9% SLO with 30-day proof.
+
+### WS-R6 — Observability (Grafana + SLO board)
+**Effort:** ~2–3 weeks. **Owner:** platform + engineering.
+
+Per the original WS8:
+
+1. **Per-service Grafana dashboards (~1 week):** tezca-api (request rate, p50/95/99 latency, error rate, deps health), tezca-worker (task rate by name, retry rate, DLQ depth), tezca-beat (drift from schedule).
+
+2. **SLO board (~1 week):** 99.9% availability for `api.tezca.mx`, p95 <500ms search / <200ms law detail. Publish to status.tezca.mx.
+
+3. **Error budget tracking:** burn-rate alerts at 2x and 14x; monthly SLO review.
+
+**Done criterion:** ≥4 Grafana dashboards deployed; SLO board live; first monthly review held.
+
+---
+
+## 4. Sequencing — what to ship next, in priority order
+
+Application-side work (WS-R1 through WS-R3) can ship next week without blockers. Platform-side work (WS-R4 through WS-R6) is gated on the platform team.
+
+| Order | Workstream | Effort | Blocker? |
+|---|---|---|:-:|
+| 1 | **WS-R1** — push backend to 65% | 3–5 days | none |
+| 2 | **WS-R2** — frontend to ≥65% / lock at 60-50-55-60 | 1–2 weeks | none |
+| 3 | **WS-R3a** — operator runs TLS capture sweep | ~1 day | needs operator session |
+| 4 | **WS-R4** — synthetic monitoring + Karafiel-test integration | 1–2 weeks | Karafiel team coord |
+| 5 | **WS-R3b** — ISO 27001 RFC | 2 weeks (operator) | none |
+| 6 | **WS-R5** — PG HA cutover (then ES, then Redis) | 6–8 weeks platform | RFC 0012 progress |
+| 7 | **WS-R6** — Grafana + SLO board | 2–3 weeks | partly gated on WS-R5 |
+
+**Realistic A+ achievement date** (if platform team executes RFC 0012 within 8 weeks): **2026-06-22** for code-side dimensions, **2026-07-15** for full A+ including infra.
+
+---
+
+## 5. Definition of done — A+ verification commands
+
+Same checklist as the original plan, updated thresholds:
+
+```bash
+# Backend
+poetry run pytest tests/ --cov=apps --cov-fail-under=60         # ≥60% gate
+poetry run pytest tests/ --no-cov -q | grep skipped              # ≤2 (each documented)
+poetry run python scripts/utils/audit_silent_excepts.py          # 0 findings
+poetry run python scripts/utils/audit_file_sizes.py | grep "0$"  # 0 files >800 LOC
+
+# Frontend
+cd apps/web && npx vitest run --coverage --coverage.reporter=text-summary
+# Statements ≥60, Branches ≥50, Functions ≥55, Lines ≥60
+
+# Infra
+kubectl get cluster postgres-ha -n data -o jsonpath='{.status.phase}'
+kubectl get elasticsearch tezca-articles -n data -o jsonpath='{.status.health}'
+kubectl get redissentinel -n data ...
+
+# Observability
+curl -s status.tezca.mx | grep "99.9"
+curl -s grafana.enclii.dev/api/dashboards | jq '.[] | select(.title | startswith("tezca"))' | wc -l  # ≥4
+
+# Security
+grep -rn "verify=False" apps/scraper/ | grep -v "# pragma: pinned"  # 0
+gh api repos/madfam-org/tezca/dependabot/alerts --jq '.[] | select(.state=="open" and .severity=="high")' | wc -l  # ≤3
+```
+
+---
+
+## 6. Risks & open questions
+
+The original plan's §5 questions are mostly resolved. What's left:
+
+1. **Engineer-weeks allocation** — the code-side workstreams (WS-R1, WS-R2, WS-R3, WS-R4) are ~3–4 weeks at 1 FTE. Can fit in a single sprint cycle.
+2. **Platform team RFC 0012 ETA** — still the gating dependency for the A+ infra dimension. If it slips past June, ship the code-side dimensions and accept a B on resilience until cutover.
+3. **TLS capture sweep risk** — some `INSECURE_HOSTS` may have rotating leaf certs (load balancers); pin only the stable ones. Acceptable per the SECURITY.md two-layer model.
+
+---
+
+## 7. Related
+
+- [`A_PLUS_REMEDIATION_PLAN_2026-04-27.md`](./A_PLUS_REMEDIATION_PLAN_2026-04-27.md) — original rubric (still authoritative for the dimensions)
+- [`COMPETITIVE_BENCHMARK_2026-04-27.md`](./COMPETITIVE_BENCHMARK_2026-04-27.md) — feature gap analysis (separate quality axis)
+- [`FEATURE_PARITY_PLAN_2026-04-27.md`](./FEATURE_PARITY_PLAN_2026-04-27.md) — product roadmap (this doc complements it)
+- [`KARAFIEL_INTEGRATION_AUDIT_2026-04-27.md`](./KARAFIEL_INTEGRATION_AUDIT_2026-04-27.md) — first-customer-readiness
+- [`CNPG_MIGRATION_PREP_2026-04-27.md`](./CNPG_MIGRATION_PREP_2026-04-27.md) — Postgres HA cutover (WS-R5 dep)

--- a/docs/strategy/INDEX.md
+++ b/docs/strategy/INDEX.md
@@ -22,7 +22,8 @@ This directory holds Tezca's product/architectural strategy. If you're new to th
 
 ## Quality / stability
 
-9. **[A_PLUS_REMEDIATION_PLAN_2026-04-27.md](./A_PLUS_REMEDIATION_PLAN_2026-04-27.md)** — 8-workstream plan to take the codebase from B+/B to A+ across 9 dimensions (test discipline, coverage, architectural integrity, code-debt, infra resilience, production validation, security, observability). Grounded in real coverage data; includes a 16-week sequenced timeline + a "5 cheapest highest-leverage items" subset for opportunistic execution.
+9. **[A_PLUS_REMEDIATION_PLAN_2026-04-27.md](./A_PLUS_REMEDIATION_PLAN_2026-04-27.md)** — Original 8-workstream plan with the rubric and rationale. Still authoritative on the dimension definitions.
+10. **[A_PLUS_PROGRESS_2026-04-27.md](./A_PLUS_PROGRESS_2026-04-27.md)** — **Live progress doc.** What shipped in PRs #55–80 (44%→61% backend coverage, 0 silent excepts, 0 files >800 LOC, TLS pinning architecture, frontend `all:true` gates). Consolidates remaining work into 6 forward workstreams (WS-R1…WS-R6) with sequencing and DoD verification commands. Read this for the *current* state.
 
 ## Subdirectories
 
@@ -58,14 +59,37 @@ These cannot be done by an agent — listed in priority order for revenue impact
 7. CNPG cluster shipping in `madfam-org/enclii` (RFC 0012)
 8. `gh repo create madfam-org/docket-watcher` + `enclii onboard` (Q1-2027)
 
+### A+ remediation — PRs #55–80 (this session)
+
+| PR | Workstream | Coverage move |
+|---|---|---|
+| #55 | WS1 1A | `scheduling/tasks.py` 0% → 73% |
+| #56 | WS3 + WS4 + WS5 + WS6 bundle | bare-except cleanup; vitest `all:true`; CVE SLO; Dependabot; scraper checklist |
+| #75 | WS3 + WS7 H7 | silent-except CI gate; TLS fingerprint pinning architecture |
+| #76 | WS1 1B | `parsers/pipeline.py` 0% → 76% |
+| #77 | WS1 1C/1D | playwright_base 0→96, scjn 22→71, treaty 14→59; gate 44→48 |
+| #78 | WS1 1C + WS2 2B | law_registry 0→71, sinec 0→69, pnt 0→66; gate 48→51; FE 51/44/47/52 → 53/46/49/54 |
+| #79 | WS1 1C/1D | 5 state scrapers 0→60-70%; gate 51→54 |
+| #80 | WS1 1C/1D | state_congress_municipal 0→55, scjn_playwright 0→36; gate 54→56 |
+
+Backend coverage: 44% → 61% (gate at 56% with 5pp headroom). 0 silent bare-except. 0 files >800 LOC. Frontend gates active at floor−3pp. Composite grade: B+/B → **B+/A−**.
+
 ### What's still pending an agent (i.e., Tezca-side engineering work)
 
+**A+ remediation (see `A_PLUS_PROGRESS_2026-04-27.md`):**
+- **WS-R1** — push backend coverage 61% → 65% (~3-5 days, no blockers)
+- **WS-R2** — frontend tests to ≥65% statements; lock at floor−2pp (~1-2 weeks)
+- **WS-R3a** — operator runs TLS fingerprint capture sweep (~1 day)
+- **WS-R4** — synthetic monitoring + Karafiel-test integration (~1-2 weeks)
+- **WS-R5** — PG/ES/Redis HA cutover (~6-8 weeks platform team)
+- **WS-R6** — Grafana dashboards + SLO board (~2-3 weeks)
+
+**Feature parity / state coverage:**
 - **Wave 1B state scrapers** — 8 medium-complexity states (Coahuila, Guanajuato, Jalisco, Puebla, Sonora, Tamaulipas, Veracruz, Sinaloa). 16/32 → 24/32 progression.
 - **Wave 1C state scrapers** — 8 hostile states needing Playwright/madfam-crawler delegation.
 - **`/preguntar` chat UI** — backend ready in #47; frontend `apps/web/app/preguntar/page.tsx` is a follow-up PR.
 - **Coverage dashboard tile flip per state** — manual per-state validation post-deploy.
 - **Public quality dashboard** — A-F grade distribution + last-update-timestamps publicized for the moat.
-- **ES HA project** — sister of RFC 0012; not yet planned.
 - **ROADMAP.md refresh** — last touched 2026-03-20; Q3-2026 → Q1-2027 priorities now in the parity plan need to land in ROADMAP.md too.
 
 ---


### PR DESCRIPTION
## Summary

Comprehensive doc refresh to reflect A+ remediation progress and chart the remaining work.

### New: \`docs/strategy/A_PLUS_PROGRESS_2026-04-27.md\`

Live progress doc mapping each of the 9 A+ dimensions to current state, summarizing the 12 PRs that shipped (PRs #55–80), and consolidating remaining work into six forward workstreams with sequencing and DoD verification commands.

| Dimension | Then | Now | Status |
|---|---|---|:-:|
| Backend coverage | C+ (44%) | **B+ (61%, gate 56)** | ✅ |
| Frontend coverage | unknown | **B (gates 53/46/49/54)** | ✅ |
| Code-debt hygiene | A− | **A (0 silent excepts, 0 files >800 LOC)** | 🟢 |
| Security posture | A− | **A (TLS pinning + CVE SLO)** | 🟡 (capture sweep) |
| Infra resilience | C− | C− (RFC 0012 in flight) | 🔴 |
| Observability | B | B | 🔴 |

**Composite: B+/B → B+/A−.**

### Updated docs
- \`docs/strategy/INDEX.md\` — adds A+ progress doc; refreshed "what's pending" with WS-R1…WS-R6
- \`CLAUDE.md\` — Quality audits section, Quality gates (PR-blocking) subsection under CI/CD, updated Key Files with audit + capture scripts and \`apps/scraper/http.py\`, A+ docs in strategy table
- \`README.md\` — corrects stale test counts (223+76+493 → 1991+ + 761 + 82) and notes 61% backend coverage with \`all: true\` frontend

## Test plan
- [x] Doc-only PR; no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)