### PR TITLE
fix(api): allow cluster-internal service DNS in default ALLOWED_HOSTS

### DIFF
--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -12,7 +12,17 @@ if not DEBUG and SECRET_KEY == "django-insecure-mock-key-for-dev":
     raise ImproperlyConfigured(
         "DJANGO_SECRET_KEY must be set in production (DEBUG=False)"
     )
-_default_hosts = "*" if DEBUG else "tezca.mx,api.tezca.mx,admin.tezca.mx"
+# Cluster-internal service-mesh DNS is allowed alongside public hostnames so
+# that consuming services (Karafiel, etc.) can reach tezca-api over
+# `tezca-api.tezca.svc.cluster.local` without each consumer having to set a
+# bespoke Host header. Per the "Integration Policy (Zero Touch)" — tezca is
+# a generic multi-tenant platform; supporting the K8s service DNS is part of
+# being a good citizen in the mesh.
+_default_hosts = (
+    "*"
+    if DEBUG
+    else "tezca.mx,api.tezca.mx,admin.tezca.mx,tezca-api.tezca.svc.cluster.local"
+)
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", _default_hosts).split(",")
 
 CORS_ALLOWED_ORIGINS = os.environ.get(


### PR DESCRIPTION
## Summary
- Add `tezca-api.tezca.svc.cluster.local` to default `ALLOWED_HOSTS` in prod.
- Operator override via `ALLOWED_HOSTS` env still wins. Public hostnames unchanged.
- Aligns with the "Integration Policy (Zero Touch)" (CLAUDE.md): tezca is a generic multi-tenant platform; supporting K8s service DNS is part of being a good citizen in the mesh.

## Why this PR exists
karafiel-api → tezca-api requests were returning HTTP 400 (`DisallowedHost`) because the prod default rejected the cluster-internal Host header. Forced every consumer to override Host on every call or hand-patch `ALLOWED_HOSTS` in `tezca-secrets`.

End-to-end fix: secret patch is unnecessary once this lands and tezca redeploys.

## Test plan
- [ ] CI passes (`poetry run pytest`, `npm run lint:all`)
- [ ] After deploy: `kubectl exec -n karafiel <api-pod> -- curl -s http://tezca-api.tezca.svc.cluster.local:8000/api/v1/laws/?page_size=1` returns 200 (anonymous tier 10/min cap permitting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)