### PR TITLE
chore: gitignore Claude Code agent scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,7 @@ audit/
 *.p12
 *.pfx
 .env.production
+
+# Claude Code agent scratch
+.claude/
+claudedocs/


### PR DESCRIPTION
Adds .claude/ and claudedocs/ to .gitignore so agent metadata doesn't pollute the working tree or accidentally get committed.

Pure additive .gitignore change. No code impact.