### PR TITLE
ci: gate test-frontend / test-mcp / test-e2e on path-filter (RFC 0017 Tier A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,52 @@ on:
     branches: [ main ]
 
 jobs:
+  # RFC 0017 Tier A — fix the false coupling where Python-only changes
+  # triggered Frontend Tests (and vice versa). Per-job conditions below
+  # gate the downstream jobs on which paths actually changed in the PR.
+  # Pushes to main always trigger every job (defensive default).
+  changes:
+    name: Detect changed scopes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+      mcp: ${{ steps.filter.outputs.mcp }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'apps/web/**'
+              - 'apps/admin/**'
+              - 'packages/api-client/**'
+              - 'packages/lib/**'
+              - 'packages/ui/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/ci.yml'
+            backend:
+              - 'apps/api/**'
+              - 'apps/indigo/**'
+              - 'apps/parsers/**'
+              - 'apps/scraper/**'
+              - 'apps/ingestion/**'
+              - 'pyproject.toml'
+              - 'poetry.lock'
+              - 'manage.py'
+              - 'tests/**'
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
+            mcp:
+              - 'packages/mcp-server/**'
+              - '.github/workflows/ci.yml'
+
   test-backend:
     name: Backend Tests (Python ${{ matrix.python-version }})
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     strategy:
@@ -77,6 +121,8 @@ jobs:
 
   test-frontend:
     name: Frontend Tests (Node ${{ matrix.node-version }})
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     strategy:
@@ -150,6 +196,8 @@ jobs:
 
   test-mcp:
     name: MCP Server Tests
+    needs: changes
+    if: needs.changes.outputs.mcp == 'true' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -174,7 +222,13 @@ jobs:
   test-e2e:
     name: E2E Tests (Playwright, Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    needs: [test-frontend, test-backend]
+    needs: [changes, test-frontend, test-backend]
+    # Run when EITHER frontend or backend changed — E2E exercises both.
+    # !cancelled() lets us run even when a needed test job was skipped
+    # (per-job path-filter conditions above), as long as nothing failed.
+    if: |
+      !cancelled() && !failure() &&
+      (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main')
     # E2E Phase 3 (active): docker-compose.e2e.yml with seeded DB + ES, blocking gate.
     # Playwright retries (2 in CI) handle transient flakes.
     strategy:


### PR DESCRIPTION
## Summary

Closes the false-coupling [RFC 0017](https://github.com/madfam-org/internal-devops/blob/main/rfcs/0017-stabilize-main-ci.md) identified as Tier A item #1: every Dependabot PR (including Python-only dep bumps like \`cryptography\`, \`weasyprint\`, \`pytest-cov\`) triggers \`Frontend Tests (Node 20|22)\` which fail for reasons unrelated to the dep being bumped — blocking the dep PR backlog from draining.

## What changed

Adds a \`dorny/paths-filter@v3\` "changes" job at the top of \`ci.yml\`. Each test job is now gated on its relevant scope:

| Job | Triggers when | Always runs on |
|---|---|---|
| \`test-backend\` | \`apps/api/**\`, \`apps/parsers/**\`, \`apps/scraper/**\`, \`pyproject.toml\`, \`poetry.lock\`, … | push to main |
| \`test-frontend\` | \`apps/web/**\`, \`apps/admin/**\`, \`packages/{api-client,lib,ui}/**\`, \`package*.json\` | push to main |
| \`test-mcp\` | \`packages/mcp-server/**\` | push to main |
| \`test-e2e\` | EITHER frontend OR backend changed (E2E exercises both) | push to main |
| \`publish-sdk\` | unchanged — already gated on push-to-main + api-client diff |

Skipped jobs on PRs no longer count as failures (\`!cancelled() && !failure()\` for \`test-e2e\`).

## Test plan

- [ ] CI green on this PR (only this workflow file changed → \`test-backend\` skips, \`test-frontend\` skips, \`test-mcp\` skips, \`test-e2e\` skips. The PR's own check listing should show "Detect changed scopes" + skipped downstream)
- [ ] Open Dependabot PRs that bump only Python deps should now stop running Frontend Tests
- [ ] Push to main still triggers everything

## Why this matters

Per [DEPENDABOT_TRIAGE_2026-05-03.md](claudedocs/DEPENDABOT_TRIAGE_2026-05-03.md), tezca had **6+ Dependabot PRs** blocked solely by this false coupling. Once this lands, those should be re-runnable and most should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)