### PR TITLE
fix(networkpolicy): allow cloudflared ingress to tezca-api

### DIFF
--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - tezca-es-service.yaml
 - tezca-es-pvc.yaml
 - tezca-pdbs.yaml
+- network-policies.yaml
 images:
 - digest: sha256:589f2bcd9989bf700ce688689b81688e9f7d4391640b5afa82215bf93fe8980e
   name: ghcr.io/madfam-org/tezca/admin

--- a/k8s/production/network-policies.yaml
+++ b/k8s/production/network-policies.yaml
@@ -1,0 +1,43 @@
+---
+# Allow Cloudflare Tunnel ingress to tezca-api.
+#
+# Background: tezca-api serves api.tezca.mx via Cloudflare Tunnel.
+# A previously-applied NetworkPolicy `tezca-api-ingress-from-karafiel`
+# (added 2026-04-28) selected `app.kubernetes.io/name: tezca-api` for
+# Ingress. Once any NetworkPolicy applies to a pod, Kubernetes default-
+# denies all OTHER ingress directions. Since no policy explicitly
+# permitted cloudflared, every external request to api.tezca.mx
+# returned HTTP 502 (status.enclii.dev incident, 2026-05-03 23:46).
+#
+# Fix: explicit allow-cloudflared-ingress for the api on port 8000.
+# Cloudflared is the trust boundary; we allow all named container
+# ports the api exposes.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared-ingress
+  namespace: tezca
+  labels:
+    app.kubernetes.io/part-of: tezca
+    app.kubernetes.io/component: networkpolicy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: tezca
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare-tunnel
+          podSelector:
+            matchLabels:
+              app: cloudflared
+      ports:
+        - protocol: TCP
+          port: 8000   # tezca-api (Django + DRF)
+        - protocol: TCP
+          port: 3000   # tezca-web (Next.js)
+        - protocol: TCP
+          port: 3001   # tezca-admin (Next.js)


### PR DESCRIPTION
## Summary

Resolves 1 active outage on status.enclii.dev (Tezca API, HTTP 502, ~21h old).

\`tezca-api-ingress-from-karafiel\` (added 2026-04-28) selected tezca-api pods for Ingress, which **auto-isolates the pod for that direction** in Kubernetes. Without an explicit allow-cloudflared rule, every external request to api.tezca.mx returned HTTP 502.

Cloudflared logs:
\`\`\`
dial tcp 10.43.57.223:8000: connect: connection refused
  → originService=http://tezca-api.tezca.svc.cluster.local:8000
\`\`\`

Pods healthy throughout — kube-probe /health returned 200, internal traffic from karafiel worked. Only Cloudflare-tunnel ingress was blocked at the CNI layer.

## Fix

Adds \`allow-cloudflared-ingress\` NetworkPolicy targeting all \`app.kubernetes.io/part-of: tezca\` pods, allowing api (8000), web (3000), admin (3001) container ports from cloudflared in the cloudflare-tunnel namespace.

Wired into \`kustomization.yaml\` for ArgoCD reconciliation.

## Operator rollout

\`\`\`bash
kubectl apply -f k8s/production/network-policies.yaml
\`\`\`

api.tezca.mx should return 200 within seconds.

## Test plan

- [ ] Operator apply, verify api.tezca.mx 200
- [ ] Verify status.enclii.dev incident auto-resolves on next probe (60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)