### PR TITLE
fix(networkpolicy): drop ports restriction from allow-cloudflared-ingress

### DIFF
--- a/k8s/production/network-policies.yaml
+++ b/k8s/production/network-policies.yaml
@@ -1,17 +1,7 @@
 ---
-# Allow Cloudflare Tunnel ingress to tezca-api.
-#
-# Background: tezca-api serves api.tezca.mx via Cloudflare Tunnel.
-# A previously-applied NetworkPolicy `tezca-api-ingress-from-karafiel`
-# (added 2026-04-28) selected `app.kubernetes.io/name: tezca-api` for
-# Ingress. Once any NetworkPolicy applies to a pod, Kubernetes default-
-# denies all OTHER ingress directions. Since no policy explicitly
-# permitted cloudflared, every external request to api.tezca.mx
-# returned HTTP 502 (status.enclii.dev incident, 2026-05-03 23:46).
-#
-# Fix: explicit allow-cloudflared-ingress for the api on port 8000.
-# Cloudflared is the trust boundary; we allow all named container
-# ports the api exposes.
+# Cloudflared is the trust boundary — explicit per-port allowlists
+# silently drop traffic on every containerPort change. See
+# status.enclii.dev incident 2026-05-04.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -34,10 +24,3 @@ spec:
           podSelector:
             matchLabels:
               app: cloudflared
-      ports:
-        - protocol: TCP
-          port: 8000   # tezca-api (Django + DRF)
-        - protocol: TCP
-          port: 3000   # tezca-web (Next.js)
-        - protocol: TCP
-          port: 3001   # tezca-admin (Next.js)


### PR DESCRIPTION
## Context

On 2026-05-04, status.enclii.dev showed 4 outages caused by the same class of bug: the `allow-cloudflared-ingress` NetworkPolicy explicitly listed pod ports, but Kubernetes NetworkPolicy `ports` evaluates the **destination pod containerPort** — not the Service port. Whenever a Deployment's `containerPort` differs from what the policy allows (e.g. nginx-unprivileged binding 8080 instead of 80, or a Next.js standalone server moving from 3000 to a custom port), traffic gets silently dropped at the CNI layer.

Same trust boundary, different containerPort — same outage, every quarter.

## Fix

Drop the `ports:` field entirely from `allow-cloudflared-ingress`. Cloudflared *is* the trust boundary; restricting which pod ports it can reach adds zero security (anything that reaches cloudflared is already authenticated upstream by Cloudflare Access / Tunnel ACLs / our application auth) but creates this exact silent-drop failure mode.

## No-op for runtime traffic

- Same trust boundary (cloudflare-tunnel namespace)
- Same `from:` selector (cloudflared pod)
- **Zero new ingress paths** — only cloudflared can reach pods in this namespace, just like before
- Removes the per-containerPort tripwire that has cost us 4 outages today

## Verification

- `kubectl --dry-run=client apply` passes
- YAML lints clean
