### PR TITLE
feat(security): allow Selva Atrium to iframe this app via CSP frame-ancestors

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -1,7 +1,24 @@
+// Selva Atrium iframe allowance — see apps/web/next.config.ts for the full rationale.
+// Tezca admin is internal-only (Janua SSO gated), surfacing it inside the Atrium does
+// not relax any third-party trust boundary.
+const SELVA_FRAME_ANCESTORS =
+    "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: "standalone",
     transpilePackages: ['@tezca/ui', '@tezca/lib', '@janua/nextjs', '@janua/ui', '@janua/typescript-sdk'],
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: [
+                    { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+                    { key: 'Content-Security-Policy', value: SELVA_FRAME_ANCESTORS },
+                ],
+            },
+        ];
+    },
 };
 
 export default nextConfig;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,15 @@
 import type { NextConfig } from "next";
 
+// Selva Atrium iframe allowance.
+// The Atrium is the consumer-side feature in selva-office that surfaces every MADFAM
+// platform as a window into a single welcoming central space. To let the Atrium
+// embed tezca.mx pages, we permit selva.town as a frame-ancestor. X-Frame-Options:
+// SAMEORIGIN remains as a legacy fallback for browsers that don't honor CSP
+// frame-ancestors. App-wide; auth surfaces (`/login`, `/api/auth/*`) inherit the
+// same policy. Acceptable because Innovaciones MADFAM runs both Selva and Tezca.
+const SELVA_FRAME_ANCESTORS =
+  "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io";
+
 const nextConfig: NextConfig = {
   output: process.env.NEXT_BUILD_STANDALONE === 'false' ? undefined : "standalone",
   transpilePackages: ['@tezca/ui', '@tezca/lib', '@janua/ui', '@janua/nextjs'],
@@ -8,6 +18,17 @@ const nextConfig: NextConfig = {
       { source: '/laws/:path*', destination: '/leyes/:path*', permanent: true },
       { source: '/search', destination: '/busqueda', permanent: true },
       { source: '/compare', destination: '/comparar', permanent: true },
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'Content-Security-Policy', value: SELVA_FRAME_ANCESTORS },
+        ],
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary

Adds `Content-Security-Policy: frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io` to both Tezca Next.js apps (`apps/web`, `apps/admin`) so the **Selva Atrium** can iframe tezca.mx and admin.tezca.mx.

`X-Frame-Options: SAMEORIGIN` stays as a legacy fallback.

## Where the policy is set

| App | Source of truth |
|---|---|
| `apps/web` (tezca.mx) | `next.config.ts` `headers()` |
| `apps/admin` | `next.config.mjs` `headers()` |
| `apps/api` (Django) | n/a — JSON-only API |

No prior CSP source existed in this repo (`grep -rE "frame-ancestors\|Content-Security-Policy" apps/` returned only test files / unrelated mentions). The Next.js `headers()` block is now the canonical layer.

## Auth-path clickjacking note

CSP is app-wide rather than path-scoped. `/login`, `/api/auth/*` inherit the same `frame-ancestors`. The clickjacking surface this opens is acceptable because Innovaciones MADFAM operates both Selva and Tezca — there is no third-party trust boundary being relaxed.

## Note on "panopticon" in docs

`docs/strategy/FEATURE_PARITY_PLAN_2026-04-27.md` mentions `panopticon-mx`, an **unrelated** external Mexican state-structure atlas repo, not the Selva metaphor. Left untouched.

## Test plan

- [ ] CI green (vitest, ESLint, build)
- [ ] Smoke: deploy preview, hit `/` and verify response headers include `Content-Security-Policy` with `selva.town` listed
- [ ] Atrium iframe smoke from selva.town

**DO NOT MERGE** — coordinated rollout with selva-office Atrium build.