### PR TITLE
feat: ecosystem marquee banner v0.1.3

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -71,6 +71,7 @@ import { ReadingProgressBar } from "@/components/ReadingProgressBar";
 import { BackToTop } from "@/components/BackToTop";
 import { PostHogProvider } from "@/components/PostHogProvider";
 import { PmfWidgetMount } from "@/components/pmf/PmfWidgetMount";
+import { EcosystemBannerClient } from "@/components/EcosystemBannerClient";
 import { Toaster } from "sonner";
 
 const januaConfig = {
@@ -86,7 +87,7 @@ export default function RootLayout({
   return (
     <html lang="es" suppressHydrationWarning>
       <body
-        className={`${inter.variable} ${sourceSerif.variable} ${jetbrainsMono.variable} font-sans antialiased min-h-screen flex flex-col bg-background text-foreground overflow-x-hidden`}
+        className={`${inter.variable} ${sourceSerif.variable} ${jetbrainsMono.variable} font-sans antialiased min-h-screen flex flex-col bg-background text-foreground overflow-x-hidden pb-8`}
       >
         <a
           href="#main-content"
@@ -116,6 +117,7 @@ export default function RootLayout({
                           <BackToTop />
                           <Toaster theme="system" position="top-right" richColors />
                           <PmfWidgetMount />
+                          <EcosystemBannerClient />
                         </PostHogProvider>
                       </Suspense>
                     </ComparisonProvider>

--- a/apps/web/components/EcosystemBannerClient.tsx
+++ b/apps/web/components/EcosystemBannerClient.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { EcosystemBanner } from '@madfam/ecosystem-banner';
+
+export function EcosystemBannerClient() {
+  return <EcosystemBanner testId="ecosystem-banner" />;
+}

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -240,13 +240,6 @@ export function Footer() {
             <LanguageToggle />
           </div>
         </div>
-        {/* Ecosystem */}
-        <div className="container mx-auto px-4 sm:px-6 pb-4 flex items-center justify-center gap-4 text-xs text-muted-foreground">
-          <span>Ecosystem:</span>
-          <a href="https://karafiel.mx" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">Karafiel</a>
-          <span aria-hidden="true">&middot;</span>
-          <a href="https://dhan.am" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">Dhanam</a>
-        </div>
       </div>
     </footer>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@janua/nextjs": "^0.1.5",
     "@janua/ui": "^0.1.1",
+    "@madfam/ecosystem-banner": "0.1.3",
     "@madfam/pmf-widget": "^0.1.0",
     "@radix-ui/react-slot": "^1.2.3",
     "@react-sigma/core": "^5.0.6",


### PR DESCRIPTION
## Summary
- Adopt `@madfam/ecosystem-banner` v0.1.3 continuous horizontal marquee (NYSE-style ticker)
- Mount `<EcosystemBanner />` on root layout with `pb-8` body padding
- Remove cross-platform ecosystem links from product footer (discovery via banner only)

## Test plan
- [ ] `pnpm build` / app build passes
- [ ] Landing shows bottom marquee with all 13 platforms
- [ ] Footer shows only platform + MADFAM company links

Part of ecosystem banner remediation — see `internal-devops/ecosystem/ecosystem-banner-footer-audit-2026-06-15.md`.

Made with [Cursor](https://cursor.com)