### PR TITLE
docs(chat): canonical Selva inference URL is now inference.selva.town/v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,7 @@ CHAT_ENABLED=false
 CHAT_BACKEND=mock
 # Required when CHAT_BACKEND=selva. The canonical public Selva domain
 # is `selva.town` (per RFC 0010 Layer 2).
-SELVA_API_URL=https://selva.example.invalid
+SELVA_API_URL=https://inference.selva.town/v1
 # Janua-relayed bearer token for the tezca service account on Selva.
 # Provisioned via the Selva onboarding ticket; rotate per the standard
 # Janua client-credentials flow.

--- a/apps/api/chat/selva_client.py
+++ b/apps/api/chat/selva_client.py
@@ -69,7 +69,7 @@ class SelvaClient:
     """Real Selva client — talks HTTP to the OpenAI-compatible /v1 endpoint.
 
     Configuration:
-    - ``SELVA_API_URL`` — base URL, e.g. ``https://selva.town/v1``
+    - ``SELVA_API_URL`` — base URL, e.g. ``https://inference.selva.town/v1``
       (canonical public domain per RFC 0010 Layer 2).
     - ``SELVA_API_TOKEN`` — Janua-relayed bearer token. The Tezca service
       account is provisioned per the §3.1 cross-cutting Selva onboarding

--- a/experiments/meta-harness/.env.example
+++ b/experiments/meta-harness/.env.example
@@ -7,7 +7,7 @@
 # --- Inference backend (one of these required) -----------------------------
 # Preferred: Selva centralized inference proxy (OpenAI-compat /v1).
 # See memory/project_inference_centralization.md.
-SELVA_API_BASE=change-me-placeholder
+SELVA_API_BASE=https://inference.selva.town/v1
 SELVA_API_KEY=change-me-placeholder
 
 # Bridge: DeepInfra direct (while Anthropic is paused or Selva's DeepInfra


### PR DESCRIPTION
Selva's `/v1` proxy now runs at **inference.selva.town** ([selva-office#211](https://github.com/madfam-org/selva-office/pull/211), RFC 0034 P2). tezca is env-driven (no in-code URL default, falls back to the stub client when unset), so this updates the documented canonical URL + `.env.example`. When `SELVA_API_URL` is set in a deploy, use `https://inference.selva.town/v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)