### PR TITLE
fix(billing): point checkout at live app.dhan.am host

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -88,6 +88,7 @@ jobs:
             NEXT_PUBLIC_API_URL=https://api.tezca.mx/api/v1
             NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY }}
             NEXT_PUBLIC_MONETIZATION_ENABLED=true
+            NEXT_PUBLIC_DHANAM_CHECKOUT_URL=https://app.dhan.am/checkout
           secrets: |
             npm_token=${{ secrets.NPM_MADFAM_TOKEN }}
           cache-from: type=gha

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ npm run dev:all                     # both concurrently
 | `INTERNAL_API_URL` | falls back to `NEXT_PUBLIC_API_URL` | Server-side API URL for SSR inside Docker (e.g. `http://api:8000/api/v1`) |
 | `CELERY_BROKER_URL` | `redis://localhost:6379/0` | Redis for Celery tasks |
 | `TEZCA_ADMIN_USER_IDS` | `""` | Comma-separated Janua user IDs allowed admin access |
-| `DHANAM_CHECKOUT_URL` | `https://dhanam.madfam.io/checkout` | Billing checkout URL (used by tier gates) |
+| `DHANAM_CHECKOUT_URL` | `https://app.dhan.am/checkout` | Billing checkout URL (used by tier gates) |
 | `TEZCA_DEPLOYMENT` | `self-hosted` | Deployment mode. `self-hosted` caps effective tier at academic |
 | `QUALITY_QUARANTINE_GRADES` | `D,F` | Comma-separated quality grades to quarantine from indexing |
 | `NEXT_PUBLIC_MONETIZATION_ENABLED` | `false` | When `true`, enables full tier checkout flows. When `false` (default), shows interest-capture forms instead of paywalls |
@@ -329,7 +329,7 @@ Consuming services configure themselves to connect to Tezca, not the other way a
 
 ### Billing
 
-- Checkout URL: `settings.DHANAM_CHECKOUT_URL` (env `DHANAM_CHECKOUT_URL`, default `https://dhanam.madfam.io/checkout`)
+- Checkout URL: `settings.DHANAM_CHECKOUT_URL` (env `DHANAM_CHECKOUT_URL`, default `https://app.dhan.am/checkout`)
 - Webhook: `POST /api/v1/billing/webhook/` — HMAC-SHA256 signed by Dhanam, upgrades/downgrades API key tiers
 - Secret: `DHANAM_WEBHOOK_SECRET` env var
 - Plan mappings: `tezca_community`, `tezca_essentials`, `tezca_academic`, `tezca_institutional`, `tezca_madfam` → corresponding tiers (legacy `tezca_pro`→`academic`)

--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -253,7 +253,7 @@ CRM_WEBHOOK_SECRET = os.environ.get("CRM_WEBHOOK_SECRET", "")
 # ── Dhanam Billing ───────────────────────────────────────────────────
 DHANAM_WEBHOOK_SECRET = os.environ.get("DHANAM_WEBHOOK_SECRET", "")
 DHANAM_CHECKOUT_URL = os.environ.get(
-    "DHANAM_CHECKOUT_URL", "https://dhanam.madfam.io/checkout"
+    "DHANAM_CHECKOUT_URL", "https://app.dhan.am/checkout"
 )
 
 # ── Logging ───────────────────────────────────────────────────────────

--- a/apps/web/__tests__/components/TierComparison.test.tsx
+++ b/apps/web/__tests__/components/TierComparison.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/components/providers/AuthContext', () => ({
 vi.mock('@/lib/billing', () => ({
     getCheckoutUrl: vi.fn(
         (tier: string, userId?: string, _returnUrl?: string) =>
-            `https://dhanam.madfam.io/checkout?tier=${tier}&uid=${userId ?? ''}`
+            `https://app.dhan.am/checkout?tier=${tier}&uid=${userId ?? ''}`
     ),
 }));
 

--- a/apps/web/__tests__/components/TierGate.test.tsx
+++ b/apps/web/__tests__/components/TierGate.test.tsx
@@ -27,7 +27,7 @@ vi.mock('@/components/providers/AuthContext', () => ({
 vi.mock('@/lib/billing', () => ({
     getCheckoutUrl: vi.fn(
         (plan: string, userId?: string) =>
-            `https://dhanam.madfam.io/checkout?plan=tezca_${plan}&product=tezca${userId ? `&user_id=${userId}` : ''}`,
+            `https://app.dhan.am/checkout?plan=tezca_${plan}&product=tezca${userId ? `&user_id=${userId}` : ''}`,
     ),
 }));
 
@@ -263,7 +263,7 @@ describe('TierGate', () => {
         const ctaLink = screen.getByText('Mejora a Academic').closest('a');
         expect(ctaLink).toBeDefined();
         // getCheckoutUrl is called with ('academic', 'user-abc', window.location.href)
-        expect(ctaLink?.getAttribute('href')).toContain('dhanam.madfam.io/checkout');
+        expect(ctaLink?.getAttribute('href')).toContain('app.dhan.am/checkout');
         expect(ctaLink?.getAttribute('href')).toContain('tezca_academic');
     });
 

--- a/apps/web/__tests__/lib/billing.test.ts
+++ b/apps/web/__tests__/lib/billing.test.ts
@@ -41,6 +41,20 @@ describe('billing', () => {
         expect(hasPaidAccess(null)).toBe(false);
     });
 
+    it('defaults to the live app.dhan.am checkout host (not the dead dhanam.madfam.io)', async () => {
+        delete process.env.NEXT_PUBLIC_DHANAM_CHECKOUT_URL;
+        const { getCheckoutUrl } = await import('@/lib/billing');
+        const url = getCheckoutUrl('academic');
+        expect(url.startsWith('https://app.dhan.am/checkout')).toBe(true);
+        expect(url).not.toContain('dhanam.madfam.io');
+    });
+
+    it('honors NEXT_PUBLIC_DHANAM_CHECKOUT_URL override', async () => {
+        process.env.NEXT_PUBLIC_DHANAM_CHECKOUT_URL = 'https://example.test/co';
+        const { getCheckoutUrl } = await import('@/lib/billing');
+        expect(getCheckoutUrl('essentials')).toContain('https://example.test/co?');
+    });
+
     it('getTrialCheckoutUrl includes mode=trial_cc', async () => {
         const { getTrialCheckoutUrl } = await import('@/lib/billing');
         const url = getTrialCheckoutUrl('academic');

--- a/apps/web/__tests__/pages/precios.test.tsx
+++ b/apps/web/__tests__/pages/precios.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/components/providers/AuthContext', () => ({
 vi.mock('@/lib/billing', () => ({
     getTrialCheckoutUrl: vi.fn(
         (plan: string, userId?: string, _returnUrl?: string) =>
-            `https://dhanam.madfam.io/checkout?plan=tezca_${plan}&mode=trial_cc`
+            `https://app.dhan.am/checkout?plan=tezca_${plan}&mode=trial_cc`
     ),
     hasPaidAccess: vi.fn(() => false),
 }));

--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -5,8 +5,13 @@
  * Uses direct URL construction (no SDK dependency needed for this minimal use case).
  */
 
+// Dhanam is served on the dhan.am apex (app.dhan.am for the customer-facing
+// checkout, api.dhan.am for the API). The legacy `dhanam.madfam.io` host was
+// never routed and does not resolve, so the previous default silently produced
+// a dead checkout link. Keep this in sync with the checkout host in
+// `app/cuenta/billing/page.tsx` (which already uses api.dhan.am).
 const DHANAM_CHECKOUT_URL =
-  process.env.NEXT_PUBLIC_DHANAM_CHECKOUT_URL || 'https://dhanam.madfam.io/checkout';
+  process.env.NEXT_PUBLIC_DHANAM_CHECKOUT_URL || 'https://app.dhan.am/checkout';
 
 export type TezaTier = 'anon' | 'free_member' | 'community' | 'essentials' | 'academic' | 'institutional' | 'madfam' | null;
 

--- a/tests/api/test_tier_permissions.py
+++ b/tests/api/test_tier_permissions.py
@@ -377,7 +377,7 @@ class TestRequireTier:
         request = self._make_request_with_tier("essentials")
         perm.has_permission(request, None)
         assert "academic tier or above" in perm.message
-        assert "dhanam.madfam.io/checkout" in perm.message
+        assert "app.dhan.am/checkout" in perm.message
 
     def test_default_min_tier_is_academic(self):
         perm = RequireTier()


### PR DESCRIPTION
## Problem
Every paid-tier CTA on `/precios` linked to `https://dhanam.madfam.io/checkout`, a host Dhanam **never routed** — it has no DNS record, so the checkout returned `HTTP 000` ("Could not resolve host"). Users could see pricing but could not buy. Dhanam serves the customer-facing checkout on **`app.dhan.am`** (this repo already uses `api.dhan.am` in `app/cuenta/billing/page.tsx`), so `billing.ts` was a stale outlier.

Verified live: `https://app.dhan.am/checkout?plan=tezca_essentials|academic|institutional` all return 200 (redirect to sign-in), confirming the host + routes exist.

## Change
- `apps/web/lib/billing.ts`: default checkout host → `https://app.dhan.am/checkout`
- `.github/workflows/deploy-web.yml`: pass `NEXT_PUBLIC_DHANAM_CHECKOUT_URL` explicitly at build time
- test: pin the default host and guard against regressing to `dhanam.madfam.io`

## Follow-up (operator / Dhanam-side, not in this PR)
Turning trials into paid conversions still needs: (a) `tezca_*` SKUs mapped to live Stripe price IDs in Dhanam's catalog, and (b) Dhanam `PRODUCT_WEBHOOK_URLS` → tezca `/api/v1/billing/webhook/` with a shared secret (tezca's receiver is already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)