### PR TITLE
feat(xref): filter low-confidence cross-references from display (audit #9)

### DIFF
--- a/apps/api/cross_reference_views.py
+++ b/apps/api/cross_reference_views.py
@@ -17,6 +17,23 @@ from apps.api.schema import (
     LawCrossRefsSchema,
 )
 
+# Cross-references below this detection confidence are likely false positives
+# (broken article detection, ambiguous matches). Filter them out of the
+# displayed refs by default — all confidences remain in the DB for analysis.
+# Consumers can widen the net with ?min_confidence=0. (2026-03-20 audit #9)
+DEFAULT_MIN_CONFIDENCE = 0.3
+
+
+def _parse_min_confidence(request):
+    """Parse the ?min_confidence= query param, clamped to [0, 1]."""
+    raw = request.query_params.get("min_confidence")
+    if raw is None:
+        return DEFAULT_MIN_CONFIDENCE
+    try:
+        return max(0.0, min(1.0, float(raw)))
+    except (TypeError, ValueError):
+        return DEFAULT_MIN_CONFIDENCE
+
 
 @extend_schema(
     tags=["Cross-References"],
@@ -35,14 +52,20 @@ def article_cross_references(request, law_id, article_id):
 
     Example: GET /api/v1/laws/amparo/articles/107/references/
     """
+    min_confidence = _parse_min_confidence(request)
+
     # Get outgoing references (references this article makes)
     outgoing_refs = CrossReference.objects.filter(
-        source_law_slug=law_id, source_article_id=article_id
+        source_law_slug=law_id,
+        source_article_id=article_id,
+        confidence__gte=min_confidence,
     ).order_by("start_position")
 
     # Get incoming references (references to this article)
     incoming_refs = CrossReference.objects.filter(
-        target_law_slug=law_id, target_article_num=article_id
+        target_law_slug=law_id,
+        target_article_num=article_id,
+        confidence__gte=min_confidence,
     ).order_by("-confidence")
 
     # Format outgoing references
@@ -120,13 +143,19 @@ def batch_article_cross_references(request, law_id):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    min_confidence = _parse_min_confidence(request)
+
     # 2 DB queries total
     outgoing_qs = CrossReference.objects.filter(
-        source_law_slug=law_id, source_article_id__in=article_ids
+        source_law_slug=law_id,
+        source_article_id__in=article_ids,
+        confidence__gte=min_confidence,
     ).order_by("source_article_id", "start_position")
 
     incoming_qs = CrossReference.objects.filter(
-        target_law_slug=law_id, target_article_num__in=article_ids
+        target_law_slug=law_id,
+        target_article_num__in=article_ids,
+        confidence__gte=min_confidence,
     ).order_by("target_article_num", "-confidence")
 
     # Group by article ID

--- a/tests/api/test_cross_reference_views.py
+++ b/tests/api/test_cross_reference_views.py
@@ -64,6 +64,47 @@ class TestArticleCrossReferences:
         assert data["outgoing"][0]["targetArticle"] == "5"
         assert data["incoming"][0]["sourceArticle"] == "3"
 
+    def test_low_confidence_refs_filtered_by_default(self):
+        """Refs below the 0.3 default floor (likely false positives) are hidden."""
+        CrossReference.objects.create(
+            source_law_slug=self.law.official_id,
+            source_article_id="1",
+            target_law_slug=self.other_law.official_id,
+            target_article_num="9",
+            reference_text="posible artículo 9",
+            confidence=0.1,
+            start_position=50,
+            end_position=70,
+        )
+        url = reverse("article-references", args=[self.law.official_id, "1"])
+        resp = self.client.get(url)
+        assert resp.status_code == 200
+        # only the 0.95 ref survives the default floor
+        assert resp.json()["total_outgoing"] == 1
+
+    def test_min_confidence_zero_includes_low_confidence(self):
+        """?min_confidence=0 opts back into every ref (kept in the DB)."""
+        CrossReference.objects.create(
+            source_law_slug=self.law.official_id,
+            source_article_id="1",
+            target_law_slug=self.other_law.official_id,
+            target_article_num="9",
+            reference_text="posible artículo 9",
+            confidence=0.1,
+            start_position=50,
+            end_position=70,
+        )
+        url = reverse("article-references", args=[self.law.official_id, "1"])
+        resp = self.client.get(url, {"min_confidence": "0"})
+        assert resp.status_code == 200
+        assert resp.json()["total_outgoing"] == 2
+
+    def test_invalid_min_confidence_falls_back_to_default(self):
+        url = reverse("article-references", args=[self.law.official_id, "1"])
+        resp = self.client.get(url, {"min_confidence": "not-a-number"})
+        assert resp.status_code == 200
+        assert resp.json()["total_outgoing"] == 1
+
     def test_outgoing_contains_target_url(self):
         url = reverse(
             "article-references",


### PR DESCRIPTION
## Gap
Closes the 2026-03-20 codebase-audit gap #9: cross-references were returned at **every** confidence (0–1), so likely false positives (ambiguous matches, broken article detection) were displayed as genuine links between laws.

## Change
- `article_cross_references` + `article_cross_references_batch` apply a **default 0.3 confidence floor** to the displayed refs.
- Overridable via `?min_confidence=` (clamped to [0,1]); `?min_confidence=0` returns everything.
- **All confidences remain in the DB** (kept for analysis / graph); this only affects display.
- The law-level *statistics* view is unchanged (aggregate counts = analysis, not display).

## Safety
Non-breaking: every existing cross-ref fixture/record is ≥0.3, so default responses are unchanged for real data. Frontends with their own confidence slider can pass `?min_confidence=0` to keep full client-side control. 28 tests pass (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)