### PR TITLE
perf(conamer): O(1) indexed name-dedup so the 113K catalog can't collapse or crawl

### DIFF
--- a/apps/api/management/commands/ingest_conamer.py
+++ b/apps/api/management/commands/ingest_conamer.py
@@ -206,15 +206,14 @@ class Command(BaseCommand):
             # Dedup: check if law already exists by official_id
             existing_law = Law.objects.filter(official_id=official_id).first()
 
-            # Also check by normalized name to catch duplicates with different IDs
+            # Also check by normalized name to catch duplicates with different
+            # IDs — O(1) against the prebuilt index (see handle()).
             if not existing_law:
-                norm_name = _normalise_for_dedup(reg_name)
-                for candidate in Law.objects.filter(
-                    tier="federal", law_type="non_legislative"
-                ).only("id", "name"):
-                    if _normalise_for_dedup(candidate.name) == norm_name:
-                        existing_law = candidate
-                        break
+                existing_id = getattr(self, "_existing_norm_index", {}).get(
+                    _normalise_for_dedup(reg_name)
+                )
+                if existing_id:
+                    existing_law = Law.objects.filter(id=existing_id).first()
 
             defaults = {
                 "name": reg_name,
@@ -236,6 +235,10 @@ class Command(BaseCommand):
             else:
                 law = Law.objects.create(official_id=official_id, **defaults)
                 action = "created"
+                # Keep the dedup index fresh so later records in this same run
+                # collapse onto this new law instead of double-creating it.
+                if hasattr(self, "_existing_norm_index"):
+                    self._existing_norm_index[_normalise_for_dedup(law.name)] = law.id
 
             # Publication date
             pub_date = None
@@ -329,6 +332,18 @@ class Command(BaseCommand):
 
         results = []
         batch_count = 0
+
+        # Build a normalized-name -> id index of the existing federal
+        # non-legislative corpus (reglamentos/NOMs/CONAMER share this bucket)
+        # ONCE, so per-record name dedup is an O(1) dict lookup instead of a
+        # full-table scan per regulation — the difference between O(N+M) and
+        # O(N*M) at 113K CONAMER records against thousands of existing laws.
+        self._existing_norm_index = {
+            _normalise_for_dedup(name): law_id
+            for law_id, name in Law.objects.filter(
+                tier="federal", law_type="non_legislative"
+            ).values_list("id", "name")
+        }
 
         for i in range(0, len(all_regulations), options["batch_size"]):
             batch = all_regulations[i : i + options["batch_size"]]

--- a/tests/api/test_management_commands.py
+++ b/tests/api/test_management_commands.py
@@ -246,6 +246,61 @@ class TestIngestConamerCommand:
 
         assert "Failed:" in captured.out
 
+    def test_dedups_against_existing_corpus_by_name(self, tmp_path):
+        """A CONAMER reg matching an existing federal non-legislative law by
+        normalized name updates it instead of creating a duplicate."""
+        Law.objects.create(
+            official_id="pre_existing_reg",
+            name="Reglamento Duplicado de Prueba",
+            tier="federal",
+            law_type="non_legislative",
+            status="vigente",
+        )
+        catalog = tmp_path / "catalog.json"
+        catalog.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "conamer_dup",
+                        "name": "Reglamento Duplicado de Prueba",
+                        "regulation_type": "reglamento",
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        call_command("ingest_conamer", "--all", "--catalog", str(catalog))
+
+        assert Law.objects.filter(name="Reglamento Duplicado de Prueba").count() == 1
+        assert not Law.objects.filter(official_id="conamer_conamer_dup").exists()
+
+    def test_dedups_within_a_single_run_by_name(self, tmp_path):
+        """Two regulations with the same name but different IDs collapse to one
+        Law (the index is kept fresh as new laws are created)."""
+        catalog = tmp_path / "catalog.json"
+        catalog.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "a1",
+                        "name": "Acuerdo Repetido",
+                        "regulation_type": "acuerdo",
+                    },
+                    {
+                        "id": "b2",
+                        "name": "Acuerdo Repetido",
+                        "regulation_type": "acuerdo",
+                    },
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        call_command("ingest_conamer", "--all", "--catalog", str(catalog))
+
+        assert Law.objects.filter(name="Acuerdo Repetido").count() == 1
+
 
 # ---------------------------------------------------------------------------
 # ingest_judicial command


### PR DESCRIPTION
## Problem
`ingest_conamer` (wired into Celery Beat in #140) deduped each regulation by **scanning the entire federal non-legislative corpus and re-normalizing every name in Python** — **O(N×M)**. At the ~113K CONAMER catalog against thousands of existing reglamentos/NOMs (same `tier=federal, law_type=non_legislative` bucket), that is pathologically slow *and* risks collapsing/double-counting — the exact risk the 2026-07-10 deep dive flagged.

## Change
- Build a normalized-name → id index **once** in `handle()` → **O(N+M)**.
- Per-record name dedup is now an O(1) dict lookup.
- Keep the index fresh as new laws are created, so two same-name records **within one run** collapse onto one law instead of double-creating.
- Tests: dedup against the existing corpus, and within-run dedup (7 CONAMER tests pass).

## Why now
This makes the CONAMER pipeline production-ready to receive the catalog once the source WAF is cleared (a data-access/partnership step — see `docs/strategy/TOTAL_CAPTURE_ROADMAP_2026-07-10.md`). Pure code hardening; no live scraping involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)