### PR TITLE
fix(judicial): replace broken SJF DOM scraping with the portal's JSON API

### DIFF
--- a/apps/scraper/judicial/scjn_playwright.py
+++ b/apps/scraper/judicial/scjn_playwright.py
@@ -1,25 +1,26 @@
 """
-SCJN Judicial Playwright Scraper (W3 — Phase 17)
+SCJN Judicial Scraper (W3 — Phase 17; API-first since #142)
 
-Browser-based scraper for the Semanario Judicial de la Federación (SJF).
-The SJF portal renders search results via JavaScript, making it inaccessible
-to requests-based scrapers. Uses Playwright to automate Chromium.
+Scraper for the Semanario Judicial de la Federación (SJF). The SJF portal
+is an Angular SPA backed by a public JSON microservice (see sjf_api.py for
+the captured contract). Scraping runs through a three-tier strategy:
 
-Architecture:
-    1. Launch Chromium via PlaywrightBase
-    2. Navigate to SJF search interface
-    3. Fill search form: epoca, materia, tipo filters
-    4. Wait for JS-rendered results table to populate
-    5. Extract record fields: registro, rubro, texto, epoca, instancia, materia
-    6. Paginate via "Siguiente" button clicks
-    7. Checkpoint every 100 items, save batches
+    Tier 1 — direct JSON API via requests (no browser). Primary path:
+             deterministic fields, full detail texto/precedentes.
+    Tier 2 — same JSON API through an in-page fetch() in Chromium, for
+             egress environments the WAF challenges (browser session
+             carries the WAF cookies).
+    Tier 3 — legacy DOM scraping (form fill + CSS selectors), kept as a
+             last resort. Historically produced empty records when the
+             SPA's markup drifted (issue #142) — do not rely on it.
+
+Common to all tiers: checkpoint every 100 items, batch saves under
+data/judicial/<tipo>/, records deduped downstream by registro.
 
 Epoch-by-epoch strategy:
-    1. Epoch 11 first (~10K items, fastest validation)
-    2. Epoch 10 (~60K jurisprudencia, highest legal value)
+    1. Epoch 11/12 first (smallest, fastest validation)
+    2. Epoch 10 (~24K tesis, highest legal value)
     3. Epochs 9→1 (historical, lower priority)
-
-Open data probe first — datos.scjn.gob.mx may have bulk CSV/JSON.
 
 Usage:
     python -m apps.scraper.judicial.scjn_playwright --check-only
@@ -39,6 +40,12 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeout
 
 from apps.scraper.client.madfam_bridge import MadfamBridge
 from apps.scraper.judicial.scjn_scraper import EPOCAS, ScjnScraper
+from apps.scraper.judicial.sjf_api import (
+    SjfApiClient,
+    SjfApiError,
+    doc_to_record,
+    strip_html,
+)
 from apps.scraper.playwright_base import PlaywrightBase
 
 logger = logging.getLogger(__name__)
@@ -86,6 +93,7 @@ class ScjnPlaywrightScraper(PlaywrightBase):
         self._epoca: int = 10
         self._tipo: str = "jurisprudencia"
         self.madfam = MadfamBridge()
+        self.api = SjfApiClient()
 
     # ------------------------------------------------------------------
     # Search form interaction
@@ -93,10 +101,12 @@ class ScjnPlaywrightScraper(PlaywrightBase):
 
     def _navigate_to_search(self) -> bool:
         """Navigate to the SJF search interface and wait for form."""
-        # Try the current search URL first, then legacy subdomain
+        # sjf2 first: it hosts the tesis microservice the in-page API
+        # fallback needs (same-origin), and sjfsemanal fronts an Imperva
+        # challenge that blocks automation outright (observed 2026-07-15).
         search_urls = [
-            SJF_SEARCH_URL,
             SJF_SEARCH_URL_LEGACY,
+            SJF_SEARCH_URL,
             f"{SJF_BASE_URL}/SJFHome/home",
             SJF_BASE_URL,
         ]
@@ -508,14 +518,38 @@ class ScjnPlaywrightScraper(PlaywrightBase):
     # Detail page enrichment
     # ------------------------------------------------------------------
 
-    def _fetch_detail_page(self, registro: str) -> Dict[str, str]:
-        """Fetch and parse a single SJF detail page for full record fields.
+    def _fetch_detail_page(
+        self, registro: str, semanal: bool = False
+    ) -> Dict[str, str]:
+        """Fetch full record fields for one tesis.
 
-        Delegates the immense layout inconsistencies and Regex requirements entirely
-        to madfam-crawler, which returns standard JSON structured_data immediately.
+        Primary: the SJF detail JSON endpoint (deterministic, returns
+        texto/precedentes directly). Fallback: madfam-crawler LLM
+        extraction against the public detail page, kept for environments
+        where the API is unreachable.
         """
-        url = f"{SJF_DETAIL_URL}/{registro}"
+        # Primary: detail API. Weekly-published records need isSemanal=true;
+        # when the flag is unknown, try the record's own hint then the
+        # opposite variant before giving up.
+        for is_semanal in dict.fromkeys([semanal, not semanal]):
+            try:
+                detail = self.api.fetch_detail(registro, semanal=is_semanal)
+            except SjfApiError:
+                continue
+            if detail and (detail.get("texto") or detail.get("rubro")):
+                return {
+                    "rubro": strip_html(detail.get("rubro")),
+                    "texto": strip_html(detail.get("texto")),
+                    "precedentes": strip_html(detail.get("precedentes")),
+                    "materia": strip_html(detail.get("materias")),
+                    "tesis_num": strip_html(detail.get("claveTesis")),
+                    "instancia": strip_html(
+                        detail.get("instanciaAbr") or detail.get("sala")
+                    ),
+                }
 
+        # Fallback: LLM extraction via madfam-crawler.
+        url = f"{SJF_DETAIL_URL}/{registro}"
         logger.info(f"Delegating detail extraction to madfam-crawler for {url}")
         prompt = "Extract the specific case details, identifying metadata like materia, tesis, instancia, ponente, and tipo. Capture the 'rubro' (the title/summary paragraph) and the core legal 'texto' body."
 
@@ -568,7 +602,9 @@ class ScjnPlaywrightScraper(PlaywrightBase):
             if not registro:
                 continue
 
-            detail = self._fetch_detail_page(registro)
+            detail = self._fetch_detail_page(
+                registro, semanal=bool(record.get("semanal"))
+            )
             if detail:
                 # Merge non-empty fields into record
                 for key, value in detail.items():
@@ -730,6 +766,169 @@ class ScjnPlaywrightScraper(PlaywrightBase):
         return all_items
 
     # ------------------------------------------------------------------
+    # API-first scraping (fix for #142)
+    # ------------------------------------------------------------------
+
+    def _save_api_batches(
+        self, all_items: List[Dict[str, Any]], batch_number: int
+    ) -> int:
+        """Flush completed batches to disk; returns the next batch number."""
+        subdir = (
+            "jurisprudencia" if self._tipo == "jurisprudencia" else "tesis_aisladas"
+        )
+        while len(all_items) >= (batch_number + 1) * _BATCH_SIZE:
+            start = batch_number * _BATCH_SIZE
+            self.save_batch(
+                all_items[start : start + _BATCH_SIZE],
+                batch_number,
+                subdirectory=subdir,
+            )
+            batch_number += 1
+        return batch_number
+
+    def _scrape_via_api(self, max_items: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Paginate the SJF tesis microservice directly — no browser.
+
+        The SPA's own JSON API returns every list field the DOM never
+        reliably exposed. Raises SjfApiError to trigger the browser
+        fallback when the API is unreachable (e.g. WAF-challenged egress).
+        """
+        all_items: List[Dict[str, Any]] = []
+        batch_number = 0
+        page = 0
+        epoca_nombre = EPOCAS.get(self._epoca, f"Epoca {self._epoca}")
+
+        while True:
+            docs, total, total_pages = self.api.list_tesis(
+                self._epoca, self._tipo, page=page, size=_BATCH_SIZE
+            )
+            if not docs:
+                break
+
+            for doc in docs:
+                all_items.append(
+                    doc_to_record(doc, self._epoca, epoca_nombre, self._tipo)
+                )
+            self._total_items = len(all_items)
+
+            logger.info(
+                "API page %d/%d: %d docs (collected: %d of %d total).",
+                page + 1,
+                max(total_pages, 1),
+                len(docs),
+                len(all_items),
+                total,
+            )
+
+            batch_number = self._save_api_batches(all_items, batch_number)
+
+            if max_items and len(all_items) >= max_items:
+                all_items = all_items[:max_items]
+                break
+            page += 1
+            if total_pages and page >= total_pages:
+                break
+
+        remaining_start = batch_number * _BATCH_SIZE
+        if remaining_start < len(all_items):
+            subdir = (
+                "jurisprudencia" if self._tipo == "jurisprudencia" else "tesis_aisladas"
+            )
+            self.save_batch(
+                all_items[remaining_start:], batch_number, subdirectory=subdir
+            )
+
+        return all_items
+
+    def _scrape_via_inpage_api(
+        self, max_items: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Call the same JSON API from inside the browser page.
+
+        Used when direct requests are WAF-blocked but a real browser
+        session passes: the page's fetch() carries the WAF cookies and
+        same-origin headers automatically. Requires the page to be on the
+        sjf2.scjn.gob.mx origin (see _navigate_to_search ordering).
+        """
+        if not self._page:
+            return []
+
+        from apps.scraper.judicial.sjf_api import build_list_body
+
+        body = build_list_body(self._epoca, self._tipo)
+        epoca_nombre = EPOCAS.get(self._epoca, f"Epoca {self._epoca}")
+        all_items: List[Dict[str, Any]] = []
+        batch_number = 0
+        page = 0
+
+        script = (
+            "async (args) => {"
+            "  const r = await fetch("
+            "    `/services/sjftesismicroservice/api/public/tesis"
+            "?page=${args.page}&size=${args.size}`,"
+            "    {method: 'POST', headers: {'Content-Type': 'application/json'},"
+            "     body: JSON.stringify(args.body)});"
+            "  if (!r.ok) return {httpError: r.status};"
+            "  return await r.json();"
+            "}"
+        )
+
+        while True:
+            try:
+                data = self._page.evaluate(
+                    script, {"body": body, "page": page, "size": _BATCH_SIZE}
+                )
+            except Exception:
+                logger.warning("In-page API fetch failed", exc_info=True)
+                break
+
+            if not isinstance(data, dict) or data.get("httpError"):
+                logger.warning(
+                    "In-page API returned error: %s",
+                    data.get("httpError") if isinstance(data, dict) else type(data),
+                )
+                break
+
+            docs = data.get("documents") or []
+            if not docs:
+                break
+            total_pages = int(data.get("totalPage") or 0)
+
+            for doc in docs:
+                all_items.append(
+                    doc_to_record(doc, self._epoca, epoca_nombre, self._tipo)
+                )
+            self._total_items = len(all_items)
+            logger.info(
+                "In-page API page %d/%d: %d docs (collected: %d).",
+                page + 1,
+                max(total_pages, 1),
+                len(docs),
+                len(all_items),
+            )
+
+            batch_number = self._save_api_batches(all_items, batch_number)
+
+            if max_items and len(all_items) >= max_items:
+                all_items = all_items[:max_items]
+                break
+            page += 1
+            if total_pages and page >= total_pages:
+                break
+            self._rate_limit()
+
+        remaining_start = batch_number * _BATCH_SIZE
+        if remaining_start < len(all_items):
+            subdir = (
+                "jurisprudencia" if self._tipo == "jurisprudencia" else "tesis_aisladas"
+            )
+            self.save_batch(
+                all_items[remaining_start:], batch_number, subdirectory=subdir
+            )
+
+        return all_items
+
+    # ------------------------------------------------------------------
     # Main pipeline
     # ------------------------------------------------------------------
 
@@ -778,32 +977,52 @@ class ScjnPlaywrightScraper(PlaywrightBase):
             "output_dir": str(self._output_dir),
         }
 
+        # If max_pages was given (legacy knob), translate to an item cap so
+        # the API paths honor it too (~_BATCH_SIZE items per API page).
+        effective_max_items = max_items
+        if max_pages and not max_items:
+            effective_max_items = max_pages * _BATCH_SIZE
+
         try:
-            self._launch()
+            # Tier 1: direct JSON API (no browser at all).
+            items: Optional[List[Dict[str, Any]]] = None
+            try:
+                items = self._scrape_via_api(max_items=effective_max_items)
+                summary["method"] = "api"
+            except SjfApiError as exc:
+                logger.warning(
+                    "Direct SJF API failed (%s) — falling back to browser.", exc
+                )
 
-            # Navigate to search
-            if not self._navigate_to_search():
-                logger.error("Cannot reach SJF search at %s", SJF_SEARCH_URL)
-                summary["error"] = "navigation_failed"
-                return summary
+            if items is None:
+                self._launch()
 
-            # Fill and submit search form
-            self._fill_search_form(epoca, tipo)
+                # Navigate to search
+                if not self._navigate_to_search():
+                    logger.error("Cannot reach SJF search at %s", SJF_SEARCH_URL)
+                    summary["error"] = "navigation_failed"
+                    return summary
 
-            # Allow JS rendering time
-            time.sleep(3)
+                # Tier 2: same JSON API through the page's fetch() —
+                # carries WAF cookies a datacenter egress can't get alone.
+                items = self._scrape_via_inpage_api(max_items=effective_max_items)
+                if items:
+                    summary["method"] = "inpage_api"
+                else:
+                    # Tier 3: legacy DOM scraping (form fill + selectors).
+                    self._fill_search_form(epoca, tipo)
+                    time.sleep(3)
 
-            # Compute max_pages from max_items if needed
-            effective_max_pages = max_pages
-            if max_items and not max_pages:
-                # Estimate ~20 items per page
-                effective_max_pages = (max_items // 20) + 2
+                    effective_max_pages = max_pages
+                    if max_items and not max_pages:
+                        # Estimate ~20 items per page
+                        effective_max_pages = (max_items // 20) + 2
 
-            # Scrape
-            items = self.scrape_catalog(
-                max_pages=effective_max_pages,
-                resume_from_page=resume_from_page,
-            )
+                    items = self.scrape_catalog(
+                        max_pages=effective_max_pages,
+                        resume_from_page=resume_from_page,
+                    )
+                    summary["method"] = "dom"
 
             if max_items and len(items) > max_items:
                 items = items[:max_items]
@@ -865,7 +1084,8 @@ class ScjnPlaywrightScraper(PlaywrightBase):
         }
 
         try:
-            self._launch()
+            # No browser needed: enrichment goes through the detail API
+            # (with madfam-crawler as a browserless HTTP fallback).
             items = self._enrich_records(items)
             enriched = sum(1 for it in items if it.get("texto"))
             summary["enriched_count"] = enriched

--- a/apps/scraper/judicial/scjn_scraper.py
+++ b/apps/scraper/judicial/scjn_scraper.py
@@ -75,6 +75,7 @@ EPOCAS = {
     9: "Novena Epoca",
     10: "Decima Epoca",
     11: "Undecima Epoca",
+    12: "Duodecima Epoca",
 }
 
 

--- a/apps/scraper/judicial/sjf_api.py
+++ b/apps/scraper/judicial/sjf_api.py
@@ -1,0 +1,255 @@
+"""
+SJF tesis microservice API client (fix for issue #142).
+
+The SJF portal (sjf2.scjn.gob.mx) is an Angular SPA whose search results
+come from a public JSON microservice. DOM scraping against the SPA is
+fragile (Material classes churn per release and the old CSS selectors
+matched nothing, producing empty records), but the underlying API is
+stable, self-describing, and returns every field the judicial pipeline
+needs — including full ``texto`` and ``precedentes`` on the detail
+endpoint, which the DOM never rendered in the result list at all.
+
+Contract (captured from the live SPA on 2026-07-15):
+
+List:
+    POST /services/sjftesismicroservice/api/public/tesis?page=N&size=M
+    body: {"classifiers": [{"name": "epoca", "value": ["Undécima Época"]},
+                           {"name": "tipoTesis", "value": ["Jurisprudencia"]},
+                           {"name": "tipoDocumento", "value": ["1"]}],
+           "searchTerms": [], "bFacet": false, "ius": [],
+           "idApp": "SJFAPP2020", "lbSearch": [], "filterExpression": ""}
+    → {"documents": [...], "classifiers": [facets], "total": N, "totalPage": N}
+
+Detail:
+    GET /services/sjftesismicroservice/api/public/tesis/{ius}
+        ?isSemanal=<bool>&hostName=https://sjf2.scjn.gob.mx
+    → full record incl. texto, precedentes, claveTesis, materias
+
+The endpoints reject requests without browser-shaped Origin/Referer
+headers ("Acceso denegado: Formato inválido"), so the session sends them.
+"""
+
+import html
+import logging
+import re
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+SJF_API_BASE = "https://sjf2.scjn.gob.mx"
+SJF_API_TESIS = f"{SJF_API_BASE}/services/sjftesismicroservice/api/public/tesis"
+SJF_APP_ID = "SJFAPP2020"
+
+# Public detail-page URL for humans (kept identical to the old scraper output
+# so downstream consumers / ingest dedup see stable URLs).
+SJF_PUBLIC_DETAIL_URL = f"{SJF_API_BASE}/detalle/tesis"
+
+# The API filters épocas by their accented display label (the repo-level
+# EPOCAS map in scjn_scraper.py is intentionally unaccented for metadata).
+EPOCA_API_LABELS = {
+    1: "Primera Época",
+    2: "Segunda Época",
+    3: "Tercera Época",
+    4: "Cuarta Época",
+    5: "Quinta Época",
+    6: "Sexta Época",
+    7: "Séptima Época",
+    8: "Octava Época",
+    9: "Novena Época",
+    10: "Décima Época",
+    11: "Undécima Época",
+    12: "Duodécima Época",
+}
+
+TIPO_API_LABELS = {
+    "jurisprudencia": "Jurisprudencia",
+    "tesis_aislada": "Aislada",
+}
+
+_REQUEST_TIMEOUT = 30  # seconds
+_RATE_LIMIT_SECONDS = 1.0  # politeness floor between API calls
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+class SjfApiError(Exception):
+    """Raised when the SJF microservice rejects or garbles a request."""
+
+
+def build_list_body(epoca: int, tipo: str) -> Dict[str, Any]:
+    """Build the POST body for the tesis list endpoint.
+
+    Shared by the direct requests path (SjfApiClient) and the in-page
+    browser fallback (ScjnPlaywrightScraper), so both speak the exact
+    same contract.
+    """
+    epoca_label = EPOCA_API_LABELS.get(epoca)
+    if not epoca_label:
+        raise SjfApiError(f"Unknown época: {epoca}")
+    tipo_label = TIPO_API_LABELS.get(tipo)
+    if not tipo_label:
+        raise SjfApiError(f"Unknown tipo: {tipo}")
+
+    return {
+        "classifiers": [
+            {
+                "name": "epoca",
+                "value": [epoca_label],
+                "allSelected": False,
+                "visible": False,
+                "isMatrix": False,
+            },
+            {
+                "name": "tipoTesis",
+                "value": [tipo_label],
+                "allSelected": False,
+                "visible": False,
+                "isMatrix": False,
+            },
+            {
+                "name": "tipoDocumento",
+                "value": ["1"],
+                "allSelected": False,
+                "visible": False,
+                "isMatrix": False,
+            },
+        ],
+        "searchTerms": [],
+        "bFacet": False,
+        "ius": [],
+        "idApp": SJF_APP_ID,
+        "lbSearch": [],
+        "filterExpression": "",
+    }
+
+
+def strip_html(value: Optional[str]) -> str:
+    """Strip tags and unescape entities from API HTML fragments."""
+    if not value:
+        return ""
+    return html.unescape(_TAG_RE.sub("", value)).strip()
+
+
+class SjfApiClient:
+    """Minimal client for the public SJF tesis microservice."""
+
+    def __init__(self, session: Optional[requests.Session] = None) -> None:
+        self._session = session or requests.Session()
+        self._session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/126.0 Safari/537.36"
+                ),
+                "Accept": "application/json, text/plain, */*",
+                "Origin": SJF_API_BASE,
+                "Referer": f"{SJF_API_BASE}/listado-resultado-tesis",
+            }
+        )
+        self._last_request_ts = 0.0
+
+    # ------------------------------------------------------------------
+    # HTTP plumbing
+    # ------------------------------------------------------------------
+
+    def _rate_limit(self) -> None:
+        elapsed = time.monotonic() - self._last_request_ts
+        if elapsed < _RATE_LIMIT_SECONDS:
+            time.sleep(_RATE_LIMIT_SECONDS - elapsed)
+        self._last_request_ts = time.monotonic()
+
+    def _check(self, resp: requests.Response, what: str) -> Dict[str, Any]:
+        if resp.status_code != 200:
+            raise SjfApiError(
+                f"SJF API {what} returned HTTP {resp.status_code}: "
+                f"{resp.text[:200]}"
+            )
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise SjfApiError(f"SJF API {what} returned non-JSON body") from exc
+
+    # ------------------------------------------------------------------
+    # Endpoints
+    # ------------------------------------------------------------------
+
+    def list_tesis(
+        self,
+        epoca: int,
+        tipo: str = "jurisprudencia",
+        page: int = 0,
+        size: int = 50,
+    ) -> Tuple[List[Dict[str, Any]], int, int]:
+        """Fetch one page of tesis for an época/tipo.
+
+        Returns:
+            (documents, total, total_pages)
+        """
+        body = build_list_body(epoca, tipo)
+
+        self._rate_limit()
+        resp = self._session.post(
+            SJF_API_TESIS,
+            params={"page": page, "size": size},
+            json=body,
+            timeout=_REQUEST_TIMEOUT,
+        )
+        data = self._check(resp, f"list(epoca={epoca}, page={page})")
+        documents = data.get("documents") or []
+        total = int(data.get("total") or 0)
+        total_pages = int(data.get("totalPage") or 0)
+        return documents, total, total_pages
+
+    def fetch_detail(self, ius: Any, semanal: bool = False) -> Dict[str, Any]:
+        """Fetch the full record (texto, precedentes, ...) for one tesis."""
+        self._rate_limit()
+        resp = self._session.get(
+            f"{SJF_API_TESIS}/{ius}",
+            params={
+                "isSemanal": "true" if semanal else "false",
+                "hostName": SJF_API_BASE,
+            },
+            timeout=_REQUEST_TIMEOUT,
+        )
+        return self._check(resp, f"detail(ius={ius})")
+
+
+def doc_to_record(
+    doc: Dict[str, Any],
+    epoca: int,
+    epoca_nombre: str,
+    tipo: str,
+) -> Dict[str, Any]:
+    """Map an API list document onto the canonical judicial record schema.
+
+    Keeps the exact field set ``ScjnPlaywrightScraper._make_record`` has
+    always produced so batches stay compatible with
+    ``ingest_judicial_batches`` and existing dedup keys.
+    """
+    registro = str(doc.get("ius") or doc.get("id") or "").strip()
+    instancia = strip_html(doc.get("instanciaAbr") or doc.get("sala") or "")
+    return {
+        "registro": registro,
+        "tipo": tipo,
+        "epoca": epoca,
+        "epoca_nombre": epoca_nombre,
+        "instancia": instancia,
+        "materia": strip_html(doc.get("materias") or ""),
+        "tesis_num": strip_html(doc.get("claveTesis") or ""),
+        "rubro": strip_html(doc.get("rubro") or ""),
+        "texto": strip_html(doc.get("texto") or ""),
+        "precedentes": strip_html(doc.get("precedentes") or ""),
+        "url": f"{SJF_PUBLIC_DETAIL_URL}/{registro}" if registro else "",
+        "source": "sjf_scjn_api",
+        # ingest_judicial reads these when present; the DOM scraper never
+        # had them, the API does.
+        "fuente": strip_html(doc.get("fuente") or ""),
+        "fecha_publicacion": (doc.get("fechaPublicacion") or "")[:10] or None,
+        # Not part of the legacy schema, but required to pick the right
+        # detail-endpoint variant; ingest ignores unknown keys.
+        "semanal": bool(doc.get("semanal")),
+    }

--- a/tests/scraper/test_scjn_playwright_full.py
+++ b/tests/scraper/test_scjn_playwright_full.py
@@ -39,8 +39,13 @@ if "playwright" not in sys.modules:
 
 
 # httpx is an optional dep used by MadfamBridge. Shim if missing.
+# NOTE: this stub is installed into sys.modules for the whole test process
+# (not just this file), so it must look enough like the real package that
+# unrelated tests collected later (e.g. elastic_transport's httpx probe in
+# test_dataops.py) don't crash on missing attributes such as __version__.
 if "httpx" not in sys.modules:
     _httpx = ModuleType("httpx")
+    _httpx.__version__ = "0.0.0-shim"  # type: ignore[attr-defined]
     _httpx.Client = MagicMock()  # type: ignore[attr-defined]
     _httpx.AsyncClient = MagicMock()  # type: ignore[attr-defined]
     _httpx.HTTPError = type("HTTPError", (Exception,), {})  # type: ignore[attr-defined]
@@ -403,3 +408,273 @@ def test_parse_page_skips_short_link_text(scraper):
 
     items = scraper._parse_page()
     assert items == []
+
+
+# ---------------------------------------------------------------------------
+# API-first scraping (fix for #142)
+# ---------------------------------------------------------------------------
+
+from apps.scraper.judicial.sjf_api import SjfApiError  # noqa: E402
+
+
+def _fake_doc(ius: str) -> dict:
+    return {
+        "ius": ius,
+        "rubro": f"<b>RUBRO {ius}</b>",
+        "texto": f"Texto {ius}",
+        "instanciaAbr": "Pleno",
+        "materias": "Civil",
+        "claveTesis": f"P./J. {ius}/2024",
+    }
+
+
+class TestScrapeViaApi:
+    """``_scrape_via_api`` — direct requests-based pagination, no browser."""
+
+    def test_two_pages_then_empty_maps_and_saves_batches(self, scraper):
+        page1 = [_fake_doc("1"), _fake_doc("2")]
+        page2 = [_fake_doc("3")]
+        scraper.api.list_tesis = MagicMock(
+            side_effect=[
+                (page1, 3, 2),
+                (page2, 3, 2),
+            ]
+        )
+
+        items = scraper._scrape_via_api()
+
+        assert [it["registro"] for it in items] == ["1", "2", "3"]
+        assert items[0]["rubro"] == "RUBRO 1"
+        assert scraper.api.list_tesis.call_count == 2
+
+    def test_saves_batches_to_output_dir(self, scraper, tmp_path):
+        docs = [_fake_doc(str(i)) for i in range(3)]
+        scraper.api.list_tesis = MagicMock(side_effect=[(docs, 3, 1)])
+
+        items = scraper._scrape_via_api()
+
+        assert len(items) == 3
+        subdir = scraper._output_dir / "jurisprudencia"
+        saved_files = list(subdir.glob("batch_*.json")) if subdir.exists() else []
+        # scrape_via_api flushes any remaining (non-full) batch at the end.
+        assert len(saved_files) >= 1
+
+    def test_max_items_honored_and_truncates(self, scraper):
+        docs = [_fake_doc(str(i)) for i in range(5)]
+        scraper.api.list_tesis = MagicMock(side_effect=[(docs, 5, 1)])
+
+        items = scraper._scrape_via_api(max_items=2)
+
+        assert len(items) == 2
+
+    def test_empty_first_page_returns_empty_list(self, scraper):
+        scraper.api.list_tesis = MagicMock(return_value=([], 0, 0))
+        items = scraper._scrape_via_api()
+        assert items == []
+
+    def test_stops_when_total_pages_reached(self, scraper):
+        docs = [_fake_doc("1")]
+        scraper.api.list_tesis = MagicMock(side_effect=[(docs, 1, 1)])
+        items = scraper._scrape_via_api()
+        assert len(items) == 1
+        scraper.api.list_tesis.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# run() — tier selection
+# ---------------------------------------------------------------------------
+
+
+class TestRunTierSelection:
+    """run() should try API first, then in-page API, then DOM as a last resort."""
+
+    def test_api_success_sets_method_api_and_skips_browser(self, scraper, tmp_path):
+        scraper._scrape_via_api = MagicMock(
+            return_value=[
+                {
+                    "registro": "1",
+                    "rubro": "R",
+                    "texto": "T",
+                    "epoca": 10,
+                    "epoca_nombre": "Decima Epoca",
+                    "tipo": "jurisprudencia",
+                }
+            ]
+        )
+        with patch.object(scraper, "_launch") as mock_launch:
+            summary = scraper.run(epoca=10, tipo="jurisprudencia", enrich=False)
+
+        mock_launch.assert_not_called()
+        assert summary["method"] == "api"
+        assert summary["total_items"] == 1
+
+    def test_api_error_falls_back_to_browser_and_launches(self, scraper):
+        scraper._scrape_via_api = MagicMock(side_effect=SjfApiError("blocked"))
+        scraper._navigate_to_search = MagicMock(return_value=True)
+        scraper._scrape_via_inpage_api = MagicMock(return_value=[])
+        scraper._fill_search_form = MagicMock(return_value=True)
+        scraper.scrape_catalog = MagicMock(return_value=[])
+
+        with patch.object(scraper, "_launch") as mock_launch, patch(
+            "apps.scraper.judicial.scjn_playwright.time.sleep"
+        ):
+            summary = scraper.run(epoca=10, tipo="jurisprudencia", enrich=False)
+
+        mock_launch.assert_called_once()
+        scraper._scrape_via_inpage_api.assert_called_once()
+        assert summary["method"] == "dom"
+
+    def test_inpage_api_success_sets_method_inpage_api(self, scraper):
+        scraper._scrape_via_api = MagicMock(side_effect=SjfApiError("blocked"))
+        scraper._navigate_to_search = MagicMock(return_value=True)
+        scraper._scrape_via_inpage_api = MagicMock(
+            return_value=[
+                {
+                    "registro": "1",
+                    "rubro": "R",
+                    "texto": "T",
+                    "epoca": 10,
+                    "epoca_nombre": "Decima Epoca",
+                    "tipo": "jurisprudencia",
+                }
+            ]
+        )
+        scraper._fill_search_form = MagicMock()
+        scraper.scrape_catalog = MagicMock()
+
+        with patch.object(scraper, "_launch") as mock_launch:
+            summary = scraper.run(epoca=10, tipo="jurisprudencia", enrich=False)
+
+        mock_launch.assert_called_once()
+        assert summary["method"] == "inpage_api"
+        scraper._fill_search_form.assert_not_called()
+        scraper.scrape_catalog.assert_not_called()
+
+    def test_falls_through_to_dom_when_inpage_api_also_empty(self, scraper):
+        scraper._scrape_via_api = MagicMock(side_effect=SjfApiError("blocked"))
+        scraper._navigate_to_search = MagicMock(return_value=True)
+        scraper._scrape_via_inpage_api = MagicMock(return_value=[])
+        scraper._fill_search_form = MagicMock(return_value=True)
+        scraper.scrape_catalog = MagicMock(
+            return_value=[
+                {
+                    "registro": "1",
+                    "rubro": "R",
+                    "texto": "T",
+                    "epoca": 10,
+                    "epoca_nombre": "Decima Epoca",
+                    "tipo": "jurisprudencia",
+                }
+            ]
+        )
+
+        with patch.object(scraper, "_launch") as mock_launch, patch(
+            "apps.scraper.judicial.scjn_playwright.time.sleep"
+        ):
+            summary = scraper.run(epoca=10, tipo="jurisprudencia", enrich=False)
+
+        mock_launch.assert_called_once()
+        scraper._fill_search_form.assert_called_once()
+        scraper.scrape_catalog.assert_called_once()
+        assert summary["method"] == "dom"
+        assert summary["total_items"] == 1
+
+    def test_navigation_failure_returns_error_summary(self, scraper):
+        scraper._scrape_via_api = MagicMock(side_effect=SjfApiError("blocked"))
+        scraper._navigate_to_search = MagicMock(return_value=False)
+
+        with patch.object(scraper, "_launch"):
+            summary = scraper.run(epoca=10, tipo="jurisprudencia", enrich=False)
+
+        assert summary["error"] == "navigation_failed"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_detail_page
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDetailPage:
+    def test_detail_api_returns_texto_madfam_not_called(self, scraper):
+        scraper.api.fetch_detail = MagicMock(
+            return_value={
+                "rubro": "<b>Rubro</b>",
+                "texto": "<p>Full body</p>",
+                "precedentes": "Prec",
+                "materias": "Civil",
+                "claveTesis": "P./J. 1/2024",
+                "instanciaAbr": "Pleno",
+            }
+        )
+        scraper.madfam.extract_sync = MagicMock()
+
+        result = scraper._fetch_detail_page("2031846", semanal=False)
+
+        assert result["rubro"] == "Rubro"
+        assert result["texto"] == "Full body"
+        assert result["precedentes"] == "Prec"
+        assert result["materia"] == "Civil"
+        assert result["tesis_num"] == "P./J. 1/2024"
+        assert result["instancia"] == "Pleno"
+        scraper.madfam.extract_sync.assert_not_called()
+
+    def test_both_semanal_variants_error_falls_back_to_madfam(self, scraper):
+        scraper.api.fetch_detail = MagicMock(side_effect=SjfApiError("not found"))
+        scraper.madfam.extract_sync = MagicMock(
+            return_value={"rubro": "From madfam", "texto": "Madfam body"}
+        )
+
+        result = scraper._fetch_detail_page("2031846", semanal=False)
+
+        assert result == {"rubro": "From madfam", "texto": "Madfam body"}
+        assert scraper.api.fetch_detail.call_count == 2
+        scraper.madfam.extract_sync.assert_called_once()
+
+    def test_first_variant_empty_second_variant_has_texto_uses_second(self, scraper):
+        scraper.api.fetch_detail = MagicMock(
+            side_effect=[
+                {},
+                {"rubro": "R2", "texto": "T2"},
+            ]
+        )
+        scraper.madfam.extract_sync = MagicMock()
+
+        result = scraper._fetch_detail_page("2031846", semanal=False)
+
+        assert result["texto"] == "T2"
+        assert scraper.api.fetch_detail.call_count == 2
+        scraper.madfam.extract_sync.assert_not_called()
+
+    def test_madfam_tesis_key_remapped_to_tesis_num(self, scraper):
+        scraper.api.fetch_detail = MagicMock(side_effect=SjfApiError("gone"))
+        scraper.madfam.extract_sync = MagicMock(
+            return_value={"rubro": "R", "texto": "T", "tesis": "P./J. 9/2024"}
+        )
+
+        result = scraper._fetch_detail_page("1", semanal=False)
+
+        assert result["tesis_num"] == "P./J. 9/2024"
+        assert "tesis" not in result
+
+
+# ---------------------------------------------------------------------------
+# run_enrich_only — no browser launch
+# ---------------------------------------------------------------------------
+
+
+class TestRunEnrichOnly:
+    def test_run_enrich_only_does_not_launch_browser(self, scraper, tmp_path):
+        input_path = tmp_path / "existing.json"
+        input_path.write_text(
+            '[{"registro": "1", "rubro": "R", "texto": "already there"}]',
+            encoding="utf-8",
+        )
+
+        with patch.object(scraper, "_launch") as mock_launch:
+            summary = scraper.run_enrich_only(
+                input_path=str(input_path), epoca=10, tipo="jurisprudencia"
+            )
+
+        mock_launch.assert_not_called()
+        assert summary["total_items"] == 1
+        assert "error" not in summary

--- a/tests/scraper/test_sjf_api.py
+++ b/tests/scraper/test_sjf_api.py
@@ -1,0 +1,414 @@
+"""Tests for ``apps.scraper.judicial.sjf_api`` (fix for issue #142).
+
+Covers the SJF tesis microservice client: list-body construction, HTML
+stripping, API-document-to-record mapping, and the requests-based client
+itself. No network calls — ``SjfApiClient`` is always constructed with a
+``MagicMock`` session, and ``session.post``/``session.get`` return
+``MagicMock`` responses with ``.status_code``/``.json()``/``.text`` stubbed.
+
+The client rate-limits via ``time.monotonic()`` (up to ~1s sleep per call);
+the ``apps.scraper.judicial.sjf_api.time`` module is patched throughout so
+tests run instantly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.scraper.judicial.sjf_api import (
+    EPOCA_API_LABELS,
+    SJF_API_TESIS,
+    SJF_PUBLIC_DETAIL_URL,
+    TIPO_API_LABELS,
+    SjfApiClient,
+    SjfApiError,
+    build_list_body,
+    doc_to_record,
+    strip_html,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_time():
+    """Neutralize the module's rate-limit sleeping across every test."""
+    with patch("apps.scraper.judicial.sjf_api.time") as mock_time:
+        mock_time.monotonic.return_value = 0.0
+        yield mock_time
+
+
+def _response(status_code: int = 200, json_body=None, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    if json_body is not None:
+        resp.json.return_value = json_body
+    else:
+        resp.json.side_effect = ValueError("no JSON object could be decoded")
+    resp.text = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# EPOCAS / TIPO label maps
+# ---------------------------------------------------------------------------
+
+
+def test_epoca_api_labels_cover_1_through_12():
+    assert set(EPOCA_API_LABELS.keys()) == set(range(1, 13))
+    assert EPOCA_API_LABELS[12] == "Duodécima Época"
+    assert EPOCA_API_LABELS[1] == "Primera Época"
+
+
+def test_tipo_api_labels_cover_jurisprudencia_and_tesis_aislada():
+    assert TIPO_API_LABELS["jurisprudencia"] == "Jurisprudencia"
+    assert TIPO_API_LABELS["tesis_aislada"] == "Aislada"
+
+
+# ---------------------------------------------------------------------------
+# build_list_body
+# ---------------------------------------------------------------------------
+
+
+def test_build_list_body_happy_path_jurisprudencia():
+    body = build_list_body(11, "jurisprudencia")
+    assert body["idApp"] == "SJFAPP2020"
+    assert body["searchTerms"] == []
+    assert body["bFacet"] is False
+    assert body["ius"] == []
+    assert body["filterExpression"] == ""
+
+    classifiers = {c["name"]: c["value"] for c in body["classifiers"]}
+    assert classifiers["epoca"] == ["Undécima Época"]
+    assert classifiers["tipoTesis"] == ["Jurisprudencia"]
+    assert classifiers["tipoDocumento"] == ["1"]
+
+
+def test_build_list_body_happy_path_tesis_aislada():
+    body = build_list_body(10, "tesis_aislada")
+    classifiers = {c["name"]: c["value"] for c in body["classifiers"]}
+    assert classifiers["epoca"] == ["Décima Época"]
+    assert classifiers["tipoTesis"] == ["Aislada"]
+
+
+@pytest.mark.parametrize("epoca", [0, 13, -1, 100])
+def test_build_list_body_unknown_epoca_raises(epoca):
+    with pytest.raises(SjfApiError, match="Unknown época"):
+        build_list_body(epoca, "jurisprudencia")
+
+
+def test_build_list_body_unknown_tipo_raises():
+    with pytest.raises(SjfApiError, match="Unknown tipo"):
+        build_list_body(11, "not_a_real_tipo")
+
+
+def test_build_list_body_all_epocas_produce_a_body():
+    for epoca in EPOCA_API_LABELS:
+        body = build_list_body(epoca, "jurisprudencia")
+        classifiers = {c["name"]: c["value"] for c in body["classifiers"]}
+        assert classifiers["epoca"] == [EPOCA_API_LABELS[epoca]]
+
+
+# ---------------------------------------------------------------------------
+# strip_html
+# ---------------------------------------------------------------------------
+
+
+def test_strip_html_removes_tags():
+    assert strip_html("<p>Hello <b>world</b></p>") == "Hello world"
+
+
+def test_strip_html_unescapes_entities():
+    assert strip_html("Tom &amp; Jerry &lt;3") == "Tom & Jerry <3"
+
+
+def test_strip_html_strips_surrounding_whitespace():
+    assert strip_html("  <div> padded </div>  ") == "padded"
+
+
+def test_strip_html_none_is_safe():
+    assert strip_html(None) == ""
+
+
+def test_strip_html_empty_string_is_safe():
+    assert strip_html("") == ""
+
+
+def test_strip_html_plain_text_passthrough():
+    assert strip_html("No tags here") == "No tags here"
+
+
+# ---------------------------------------------------------------------------
+# doc_to_record
+# ---------------------------------------------------------------------------
+
+
+def test_doc_to_record_maps_full_document():
+    doc = {
+        "ius": "2031846",
+        "rubro": "<b>RUBRO TEXT</b>",
+        "texto": "<p>Body &amp; text</p>",
+        "precedentes": "<i>Precedente</i>",
+        "claveTesis": "P./J. 1/2024",
+        "materias": "Civil",
+        "instanciaAbr": "Pleno",
+        "fuente": "Semanario Judicial",
+        "fechaPublicacion": "2024-05-01T00:00:00.000Z",
+        "semanal": True,
+    }
+    rec = doc_to_record(doc, 11, "Undecima Epoca", "jurisprudencia")
+
+    assert rec["registro"] == "2031846"
+    assert rec["tipo"] == "jurisprudencia"
+    assert rec["epoca"] == 11
+    assert rec["epoca_nombre"] == "Undecima Epoca"
+    assert rec["instancia"] == "Pleno"
+    assert rec["materia"] == "Civil"
+    assert rec["tesis_num"] == "P./J. 1/2024"
+    assert rec["rubro"] == "RUBRO TEXT"
+    assert rec["texto"] == "Body & text"
+    assert rec["precedentes"] == "Precedente"
+    assert rec["url"] == f"{SJF_PUBLIC_DETAIL_URL}/2031846"
+    assert rec["source"] == "sjf_scjn_api"
+    assert rec["fuente"] == "Semanario Judicial"
+    assert rec["fecha_publicacion"] == "2024-05-01"
+    assert rec["semanal"] is True
+
+
+def test_doc_to_record_falls_back_to_id_when_ius_missing():
+    doc = {"id": "999", "rubro": "X"}
+    rec = doc_to_record(doc, 10, "Decima Epoca", "jurisprudencia")
+    assert rec["registro"] == "999"
+    assert rec["url"] == f"{SJF_PUBLIC_DETAIL_URL}/999"
+
+
+def test_doc_to_record_falls_back_to_sala_for_instancia():
+    doc = {"ius": "1", "sala": "Primera Sala"}
+    rec = doc_to_record(doc, 10, "Decima Epoca", "jurisprudencia")
+    assert rec["instancia"] == "Primera Sala"
+
+
+def test_doc_to_record_empty_registro_yields_empty_url():
+    doc = {}
+    rec = doc_to_record(doc, 10, "Decima Epoca", "jurisprudencia")
+    assert rec["registro"] == ""
+    assert rec["url"] == ""
+
+
+def test_doc_to_record_missing_fecha_publicacion_is_none():
+    doc = {"ius": "1"}
+    rec = doc_to_record(doc, 10, "Decima Epoca", "jurisprudencia")
+    assert rec["fecha_publicacion"] is None
+
+
+def test_doc_to_record_blank_fecha_publicacion_is_none():
+    doc = {"ius": "1", "fechaPublicacion": ""}
+    rec = doc_to_record(doc, 10, "Decima Epoca", "jurisprudencia")
+    assert rec["fecha_publicacion"] is None
+
+
+def test_doc_to_record_fecha_publicacion_truncated_to_date_part():
+    doc = {"ius": "1", "fechaPublicacion": "2023-11-30T12:34:56.000Z"}
+    rec = doc_to_record(doc, 10, "Decima Epoca", "jurisprudencia")
+    assert rec["fecha_publicacion"] == "2023-11-30"
+
+
+def test_doc_to_record_semanal_defaults_false():
+    doc = {"ius": "1"}
+    rec = doc_to_record(doc, 10, "Decima Epoca", "jurisprudencia")
+    assert rec["semanal"] is False
+
+
+def test_doc_to_record_tesis_aislada_tipo_preserved():
+    doc = {"ius": "1"}
+    rec = doc_to_record(doc, 10, "Decima Epoca", "tesis_aislada")
+    assert rec["tipo"] == "tesis_aislada"
+
+
+# ---------------------------------------------------------------------------
+# SjfApiClient.list_tesis
+# ---------------------------------------------------------------------------
+
+
+def test_list_tesis_happy_path_returns_documents_total_and_pages():
+    session = MagicMock()
+    session.post.return_value = _response(
+        200,
+        json_body={
+            "documents": [{"ius": "1"}, {"ius": "2"}],
+            "total": 45,
+            "totalPage": 5,
+        },
+    )
+    client = SjfApiClient(session=session)
+
+    docs, total, total_pages = client.list_tesis(11, "jurisprudencia", page=0, size=10)
+
+    assert docs == [{"ius": "1"}, {"ius": "2"}]
+    assert total == 45
+    assert total_pages == 5
+    session.post.assert_called_once()
+    call_kwargs = session.post.call_args
+    assert call_kwargs.args[0] == SJF_API_TESIS
+    assert call_kwargs.kwargs["params"] == {"page": 0, "size": 10}
+    assert "classifiers" in call_kwargs.kwargs["json"]
+
+
+def test_list_tesis_defaults_to_jurisprudencia_page0_size50():
+    session = MagicMock()
+    session.post.return_value = _response(
+        200, json_body={"documents": [], "total": 0, "totalPage": 0}
+    )
+    client = SjfApiClient(session=session)
+    client.list_tesis(11)
+    call_kwargs = session.post.call_args
+    assert call_kwargs.kwargs["params"] == {"page": 0, "size": 50}
+
+
+def test_list_tesis_missing_documents_key_returns_empty_list():
+    session = MagicMock()
+    session.post.return_value = _response(200, json_body={"total": 0, "totalPage": 0})
+    client = SjfApiClient(session=session)
+    docs, total, total_pages = client.list_tesis(11)
+    assert docs == []
+    assert total == 0
+    assert total_pages == 0
+
+
+def test_list_tesis_non_200_raises_sjf_api_error():
+    session = MagicMock()
+    session.post.return_value = _response(500, text="Internal Server Error")
+    client = SjfApiClient(session=session)
+    with pytest.raises(SjfApiError, match="HTTP 500"):
+        client.list_tesis(11)
+
+
+def test_list_tesis_non_json_body_raises_sjf_api_error():
+    session = MagicMock()
+    session.post.return_value = _response(200, json_body=None, text="not json")
+    client = SjfApiClient(session=session)
+    with pytest.raises(SjfApiError, match="non-JSON body"):
+        client.list_tesis(11)
+
+
+def test_list_tesis_unknown_epoca_raises_before_any_request():
+    session = MagicMock()
+    client = SjfApiClient(session=session)
+    with pytest.raises(SjfApiError, match="Unknown época"):
+        client.list_tesis(999)
+    session.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# SjfApiClient.fetch_detail
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_detail_happy_path_gets_with_is_semanal_true():
+    session = MagicMock()
+    session.get.return_value = _response(
+        200, json_body={"ius": "2031846", "texto": "Full text"}
+    )
+    client = SjfApiClient(session=session)
+
+    detail = client.fetch_detail("2031846", semanal=True)
+
+    assert detail == {"ius": "2031846", "texto": "Full text"}
+    session.get.assert_called_once()
+    call_kwargs = session.get.call_args
+    assert call_kwargs.args[0] == f"{SJF_API_TESIS}/2031846"
+    assert call_kwargs.kwargs["params"]["isSemanal"] == "true"
+
+
+def test_fetch_detail_semanal_false_sets_is_semanal_false():
+    session = MagicMock()
+    session.get.return_value = _response(200, json_body={})
+    client = SjfApiClient(session=session)
+    client.fetch_detail("1", semanal=False)
+    call_kwargs = session.get.call_args
+    assert call_kwargs.kwargs["params"]["isSemanal"] == "false"
+
+
+def test_fetch_detail_includes_hostname_param():
+    session = MagicMock()
+    session.get.return_value = _response(200, json_body={})
+    client = SjfApiClient(session=session)
+    client.fetch_detail("1")
+    call_kwargs = session.get.call_args
+    assert "hostName" in call_kwargs.kwargs["params"]
+
+
+def test_fetch_detail_non_200_raises_sjf_api_error():
+    session = MagicMock()
+    session.get.return_value = _response(404, text="Not Found")
+    client = SjfApiClient(session=session)
+    with pytest.raises(SjfApiError, match="HTTP 404"):
+        client.fetch_detail("1")
+
+
+def test_fetch_detail_non_json_body_raises_sjf_api_error():
+    session = MagicMock()
+    session.get.return_value = _response(200, json_body=None, text="oops")
+    client = SjfApiClient(session=session)
+    with pytest.raises(SjfApiError, match="non-JSON body"):
+        client.fetch_detail("1")
+
+
+# ---------------------------------------------------------------------------
+# SjfApiClient — session setup / rate limiting
+# ---------------------------------------------------------------------------
+
+
+def test_client_sets_browser_shaped_headers_on_session():
+    session = MagicMock()
+    SjfApiClient(session=session)
+    session.headers.update.assert_called_once()
+    headers = session.headers.update.call_args.args[0]
+    assert "User-Agent" in headers
+    assert headers["Origin"] == "https://sjf2.scjn.gob.mx"
+    assert "Referer" in headers
+
+
+def test_client_defaults_to_new_requests_session_when_none_given():
+    client = SjfApiClient()
+    assert client._session is not None
+
+
+def test_rate_limit_sleeps_when_called_in_quick_succession(_patch_time):
+    session = MagicMock()
+    session.post.return_value = _response(
+        200, json_body={"documents": [], "total": 0, "totalPage": 0}
+    )
+    client = SjfApiClient(session=session)
+
+    # _rate_limit() calls time.monotonic() twice per request: once to
+    # compute elapsed-since-last-call, once to stamp _last_request_ts after
+    # the (possible) sleep. First call: elapsed vs the initial 0.0 timestamp
+    # is 0.0 (< the 1s floor) so it sleeps; second call: elapsed since the
+    # first call's post-sleep stamp is still 0.0, so it sleeps again too.
+    _patch_time.monotonic.side_effect = [0.0, 0.0, 0.1, 0.1]
+    client.list_tesis(11)
+    client.list_tesis(11)
+
+    assert _patch_time.sleep.called
+
+
+def test_rate_limit_does_not_sleep_when_interval_elapsed(_patch_time):
+    session = MagicMock()
+    session.post.return_value = _response(
+        200, json_body={"documents": [], "total": 0, "totalPage": 0}
+    )
+    client = SjfApiClient(session=session)
+
+    # First call: elapsed since init (ts=0.0) is 0.0 → sleeps once and
+    # stamps _last_request_ts at 5.0. Second call: elapsed since 5.0 is
+    # also >= the 1s floor (10.0 - 5.0), so no further sleep.
+    _patch_time.monotonic.side_effect = [0.0, 5.0, 10.0, 10.0]
+    client.list_tesis(11)
+    client.list_tesis(11)
+
+    _patch_time.sleep.assert_called_once()


### PR DESCRIPTION
Fixes #142.

## Problem
The SJF SPA's CSS selectors (`.resultado, .tesis-item, …`) match nothing in the live Angular DOM, so scheduled scrapes fell through to a link-text fallback producing empty records (`rubro='1. Registro digital: …'`, no texto). `ingest_judicial` correctly skips those as degenerate — so the judicial corpus never grew while `AcquisitionLog` reported success.

## Fix
The SPA is backed by a public JSON microservice; the full contract was captured from the live app and is documented in the new `apps/scraper/judicial/sjf_api.py`. Scraping now runs a three-tier strategy:

1. **Direct JSON API** (requests, no browser) — list + detail with full `texto`/`precedentes`/`claveTesis`/`materias`/`fuente`/`fecha_publicacion` — fields the DOM never rendered.
2. **In-page `fetch()`** of the same API through Chromium, for egress environments the portal's WAF challenges (sjf2 origin now ordered first — the sjfsemanal host hard-blocks automation).
3. **Legacy DOM scraping** kept as last resort only.

Detail enrichment is API-first (LLM crawler demoted to fallback); enrich-only mode no longer launches a browser. `EPOCAS` gains 12 (Duodécima Época). Record schema unchanged — `ingest_judicial` dedup and the batch/consolidated file layout are untouched.

## Verification
- **Live smoke test** (`epoca=11, tipo=jurisprudencia, max_items=5, enrich=True`): `method=api`, 5/5 records fully populated (texto ~2K chars, precedentes, materia, tesis_num, instancia) against **2,838** available records — the old path had produced 28 empty rows total.
- 40 new tests for `sjf_api`, 4 new test classes for tier selection / pagination / detail fallback.
- Full scraper suite: **894 passed, 4 skipped** (pre-existing boto3 skips).
- black, isort, silent-except and file-size gates clean.

Python-only path → frontend CI jobs skip (not blocked by the expired NPM token, #148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)