### PR TITLE
fix(analytics): posthog wrapper compatibility with both 3.x and 6+/7.x

### DIFF
--- a/apps/api/posthog_analytics.py
+++ b/apps/api/posthog_analytics.py
@@ -54,7 +54,14 @@ def track(distinct_id: str, event: str, properties: Optional[dict] = None) -> No
     if _client is None:
         return
     try:
-        _client.capture(distinct_id, event, properties=properties or {})
+        # Keyword form binds on both posthog majors: 3.x is
+        # capture(distinct_id, event, ...), 6+/7.x is
+        # capture(event, *, distinct_id=..., ...) — positional args would
+        # TypeError on 6+ and silently kill all telemetry via the
+        # except below.
+        _client.capture(
+            event=event, distinct_id=distinct_id, properties=properties or {}
+        )
     except Exception:
         # Telemetry must never break a request. Log at debug for visibility
         # without polluting production logs with PostHog network blips.
@@ -65,7 +72,12 @@ def identify(distinct_id: str, properties: Optional[dict] = None) -> None:
     if _client is None:
         return
     try:
-        _client.identify(distinct_id, properties=properties or {})
+        # posthog 6+ removed module-level identify(); set() is its
+        # replacement for attaching person properties.
+        if hasattr(_client, "identify"):
+            _client.identify(distinct_id, properties=properties or {})
+        else:
+            _client.set(distinct_id=distinct_id, properties=properties or {})
     except Exception:
         logger.debug("PostHog identify() failed", exc_info=True)
 

--- a/tests/api/test_posthog_analytics.py
+++ b/tests/api/test_posthog_analytics.py
@@ -1,0 +1,93 @@
+"""Tests for the posthog_analytics wrapper.
+
+The wrapper must speak both posthog-python majors: 3.x
+(``capture(distinct_id, event)``, module-level ``identify()``) and 6+/7.x
+(``capture(event, *, distinct_id=...)``, ``identify()`` removed in favour
+of ``set()``). A silent regression here no-ops all product telemetry —
+the calls are wrapped in broad excepts by design, so nothing else would
+surface it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from apps.api import posthog_analytics
+
+
+class _V7StyleClient:
+    """Mimics posthog 6+/7.x: keyword-only capture, no identify()."""
+
+    def __init__(self):
+        self.capture_calls = []
+        self.set_calls = []
+
+    def capture(self, event=None, *, distinct_id=None, properties=None, **kw):
+        if not isinstance(event, str):
+            raise TypeError("capture() event must be the first argument")
+        self.capture_calls.append((event, distinct_id, properties))
+
+    def set(self, *, distinct_id=None, properties=None, **kw):
+        self.set_calls.append((distinct_id, properties))
+
+    # NOTE: no identify() attribute, matching 6+.
+
+
+class _V3StyleClient:
+    """Mimics posthog 3.x: capture(distinct_id, event), identify()."""
+
+    def __init__(self):
+        self.capture_calls = []
+        self.identify_calls = []
+
+    def capture(self, distinct_id=None, event=None, properties=None, **kw):
+        self.capture_calls.append((distinct_id, event, properties))
+
+    def identify(self, distinct_id, properties=None, **kw):
+        self.identify_calls.append((distinct_id, properties))
+
+
+class TestTrack:
+    def test_noop_when_client_unset(self):
+        with patch.object(posthog_analytics, "_client", None):
+            posthog_analytics.track("user-1", "law_viewed")  # must not raise
+
+    def test_v7_client_receives_keyword_call(self):
+        client = _V7StyleClient()
+        with patch.object(posthog_analytics, "_client", client):
+            posthog_analytics.track("user-1", "law_viewed", {"law": "cpeum"})
+        assert client.capture_calls == [("law_viewed", "user-1", {"law": "cpeum"})]
+
+    def test_v3_client_receives_keyword_call(self):
+        client = _V3StyleClient()
+        with patch.object(posthog_analytics, "_client", client):
+            posthog_analytics.track("user-1", "law_viewed")
+        assert client.capture_calls == [("user-1", "law_viewed", {})]
+
+    def test_capture_exception_is_swallowed(self):
+        client = MagicMock()
+        client.capture.side_effect = RuntimeError("network blip")
+        with patch.object(posthog_analytics, "_client", client):
+            posthog_analytics.track("user-1", "law_viewed")  # must not raise
+
+
+class TestIdentify:
+    def test_noop_when_client_unset(self):
+        with patch.object(posthog_analytics, "_client", None):
+            posthog_analytics.identify("user-1")  # must not raise
+
+    def test_v3_client_uses_identify(self):
+        client = _V3StyleClient()
+        with patch.object(posthog_analytics, "_client", client):
+            posthog_analytics.identify("user-1", {"tier": "academic"})
+        assert client.identify_calls == [("user-1", {"tier": "academic"})]
+
+    def test_v7_client_falls_back_to_set(self):
+        client = _V7StyleClient()
+        with patch.object(posthog_analytics, "_client", client):
+            posthog_analytics.identify("user-1", {"tier": "academic"})
+        assert client.set_calls == [("user-1", {"tier": "academic"})]
+
+    def test_identify_exception_is_swallowed(self):
+        client = _V3StyleClient()
+        client.identify = MagicMock(side_effect=RuntimeError("boom"))
+        with patch.object(posthog_analytics, "_client", client):
+            posthog_analytics.identify("user-1")  # must not raise


### PR DESCRIPTION
Pre-merge review of #133 (posthog 3.25→7.22) found the wrapper breaks silently on the new major:

- `capture(distinct_id, event)` positional → **TypeError** on 6+ (`capture(event, *, distinct_id=...)`)
- module-level `identify()` **removed** on 6+ (replaced by `set()`)

Both failures land in the wrapper's intentional broad excepts, so merging #133 as-is would silently no-op **all** product telemetry (9 call sites: funnels, trials, exports, billing, search) with zero CI signal — analytics paths only run when `POSTHOG_API_KEY` is set.

Fix: keyword-form `capture(event=, distinct_id=, properties=)` binds on both majors; `identify()` falls back to `set()` when absent. 8 new tests pin both client shapes (a v3-style and a v7-style stub).

Merge order: this first, then #133 (either order is safe at runtime — the wrapper now speaks both dialects — but this way the bump lands pre-verified).

Python-only path → frontend CI jobs skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)