### PR TITLE
fix(dataops): schedule RMF + treaty catalog ingest (wiring-gap class)

### DIFF
--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -383,6 +383,12 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(hour=2, minute=0, day_of_week="wednesday"),
         "kwargs": {"fetch_details": True, "max_details": 50},
     },
+    # Ingest three hours after the weekly treaty scrape — the discovered
+    # catalog previously had no scheduled consumer (wiring-gap class).
+    "treaty-catalog-ingest-weekly": {
+        "task": "dataops.ingest_treaty_catalog",
+        "schedule": crontab(hour=5, minute=0, day_of_week="wednesday"),
+    },
     "nom-weekly-discovery": {
         "task": "dataops.run_nom_scraper",
         "schedule": crontab(hour=3, minute=0, day_of_week="thursday"),
@@ -458,6 +464,15 @@ CELERY_BEAT_SCHEDULE = {
             hour=3, minute=0, day_of_month="8", month_of_year="1,4,7,10"
         ),
         "kwargs": {"include_annexes": True, "download_documents": True},
+    },
+    # Ingest the day after the quarterly scrape — without this the RMF
+    # catalog only ever reached disk, never the Law table (wiring-gap
+    # class; see ingest_conamer_catalog).
+    "rmf-catalog-ingest-quarterly": {
+        "task": "dataops.ingest_rmf_catalog",
+        "schedule": crontab(
+            hour=3, minute=0, day_of_month="9", month_of_year="1,4,7,10"
+        ),
     },
     "conamer-playwright-weekly": {
         "task": "dataops.run_conamer_playwright",

--- a/apps/scraper/scheduling/tasks.py
+++ b/apps/scraper/scheduling/tasks.py
@@ -820,6 +820,69 @@ def ingest_conamer_catalog():
         return {"status": "error", "error": str(e)}
 
 
+@shared_task(name="dataops.ingest_rmf_catalog")
+def ingest_rmf_catalog():
+    """Auto-ingest the scraped RMF catalog into the database.
+
+    ``run_rmf_scraper`` (quarterly, day 8) only writes
+    ``data/rmf/catalog.json`` — nothing scheduled ``ingest_rmf``, so SAT
+    resolutions never reached the Law table (and Karafiel's fiscal
+    webhook feed never fired) despite green scrapes. Same wiring-gap
+    class as the CONAMER/judicial/DOF fixes; mirrors
+    ``ingest_conamer_catalog``. Scheduled day 9, the day after the
+    quarterly scrape.
+    """
+    from pathlib import Path
+
+    from django.core.management import call_command
+
+    catalog = Path("data/rmf/catalog.json")
+    if not catalog.exists():
+        logger.info("No RMF catalog to ingest")
+        return {"status": "no_files"}
+
+    log_entry = _start_log("rmf_catalog_ingest")
+    try:
+        call_command("ingest_rmf", catalog=str(catalog))
+        _finish_log(log_entry, ingested=1)
+        return {"status": "completed"}
+    except Exception as e:
+        logger.error("RMF catalog ingest failed: %s", e)
+        _finish_log(log_entry, error=str(e))
+        return {"status": "error", "error": str(e)}
+
+
+@shared_task(name="dataops.ingest_treaty_catalog")
+def ingest_treaty_catalog():
+    """Auto-ingest discovered treaties into the database.
+
+    ``run_treaty_scraper`` (weekly, Wednesday 02:00) only writes
+    ``data/treaties/discovered_treaties.json`` — the ``ingest_treaties``
+    command reads exactly that file but was only invoked manually (or by
+    the unscheduled overnight script), so treaties never landed
+    automatically. Mirrors ``ingest_conamer_catalog``; scheduled
+    Wednesday 05:00, after the weekly scrape.
+    """
+    from pathlib import Path
+
+    from django.core.management import call_command
+
+    catalog = Path("data/treaties/discovered_treaties.json")
+    if not catalog.exists():
+        logger.info("No treaty catalog to ingest")
+        return {"status": "no_files"}
+
+    log_entry = _start_log("treaty_catalog_ingest")
+    try:
+        call_command("ingest_treaties", all=True)
+        _finish_log(log_entry, ingested=1)
+        return {"status": "completed"}
+    except Exception as e:
+        logger.error("Treaty catalog ingest failed: %s", e)
+        _finish_log(log_entry, error=str(e))
+        return {"status": "error", "error": str(e)}
+
+
 @shared_task(name="dataops.classify_law_domains")
 def classify_law_domains_task():
     """Weekly domain classification for newly added laws."""

--- a/tests/scraper/test_scheduling_tasks.py
+++ b/tests/scraper/test_scheduling_tasks.py
@@ -723,6 +723,100 @@ class TestIngestConamerCatalog:
         mock_call_command.assert_called_once_with("ingest_conamer", all=True)
 
 
+# ── ingest_rmf_catalog ────────────────────────────────────────────────
+
+
+class TestIngestRmfCatalog:
+    def test_no_catalog_short_circuits(self, tmp_path, monkeypatch):
+        """No data/rmf/catalog.json → clean no-op."""
+        from apps.scraper.scheduling import tasks
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_rmf_catalog()
+        assert result["status"] == "no_files"
+
+    @patch("apps.scraper.dataops.models.AcquisitionLog")
+    @patch("django.core.management.call_command")
+    def test_runs_ingest_when_catalog_present(
+        self, mock_call_command, mock_log_cls, tmp_path, monkeypatch
+    ):
+        from apps.scraper.scheduling import tasks
+
+        rmf_dir = tmp_path / "data" / "rmf"
+        rmf_dir.mkdir(parents=True)
+        (rmf_dir / "catalog.json").write_text("{}")
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_rmf_catalog()
+        assert result["status"] == "completed"
+        mock_call_command.assert_called_once_with(
+            "ingest_rmf", catalog="data/rmf/catalog.json"
+        )
+
+    @patch("apps.scraper.dataops.models.AcquisitionLog")
+    @patch("django.core.management.call_command")
+    def test_error_is_reported_not_raised(
+        self, mock_call_command, mock_log_cls, tmp_path, monkeypatch
+    ):
+        from apps.scraper.scheduling import tasks
+
+        rmf_dir = tmp_path / "data" / "rmf"
+        rmf_dir.mkdir(parents=True)
+        (rmf_dir / "catalog.json").write_text("{}")
+        mock_call_command.side_effect = RuntimeError("ingest boom")
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_rmf_catalog()
+        assert result["status"] == "error"
+        assert "ingest boom" in result["error"]
+
+
+# ── ingest_treaty_catalog ─────────────────────────────────────────────
+
+
+class TestIngestTreatyCatalog:
+    def test_no_catalog_short_circuits(self, tmp_path, monkeypatch):
+        """No discovered_treaties.json → clean no-op."""
+        from apps.scraper.scheduling import tasks
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_treaty_catalog()
+        assert result["status"] == "no_files"
+
+    @patch("apps.scraper.dataops.models.AcquisitionLog")
+    @patch("django.core.management.call_command")
+    def test_runs_ingest_when_catalog_present(
+        self, mock_call_command, mock_log_cls, tmp_path, monkeypatch
+    ):
+        from apps.scraper.scheduling import tasks
+
+        treaties_dir = tmp_path / "data" / "treaties"
+        treaties_dir.mkdir(parents=True)
+        (treaties_dir / "discovered_treaties.json").write_text("[]")
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_treaty_catalog()
+        assert result["status"] == "completed"
+        mock_call_command.assert_called_once_with("ingest_treaties", all=True)
+
+    @patch("apps.scraper.dataops.models.AcquisitionLog")
+    @patch("django.core.management.call_command")
+    def test_error_is_reported_not_raised(
+        self, mock_call_command, mock_log_cls, tmp_path, monkeypatch
+    ):
+        from apps.scraper.scheduling import tasks
+
+        treaties_dir = tmp_path / "data" / "treaties"
+        treaties_dir.mkdir(parents=True)
+        (treaties_dir / "discovered_treaties.json").write_text("[]")
+        mock_call_command.side_effect = RuntimeError("treaty boom")
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_treaty_catalog()
+        assert result["status"] == "error"
+        assert "treaty boom" in result["error"]
+
+
 # ── classify_law_domains_task ─────────────────────────────────────────
 
 


### PR DESCRIPTION
Same bug class as the three 2026-07-10 fixes (#140 CONAMER, #141 judicial, #146 DOF): a scheduled scraper writes output that nothing ever ingests, so the corpus silently stops growing while `AcquisitionLog` reports success.

## What
- **`dataops.ingest_rmf_catalog`** — reads `data/rmf/catalog.json` → `ingest_rmf`; scheduled day 9 of Jan/Apr/Jul/Oct (the quarterly scrape runs day 8). Until now the RMF catalog only ever reached disk — SAT resolutions never landed in the Law table, so the `domains=["fiscal"]` webhook fanout never fired.
- **`dataops.ingest_treaty_catalog`** — reads `data/treaties/discovered_treaties.json` → `ingest_treaties --all`; scheduled Wednesday 05:00 (scrape runs 02:00). The ingest command existed and read exactly this path, but only manual/overnight-script invocations ever called it.

Both mirror `ingest_conamer_catalog` exactly: no-op when the catalog is absent, AcquisitionLog-wrapped, errors reported not raised.

## Tests
6 new tests (no-op / happy path / error path per task) following the existing `TestIngestConamerCatalog` pattern. `tests/scraper/test_scheduling_tasks.py`: 55 passed.

## Not in scope
NOM, OJN/wayback recovery, and state scrapers have the same class of gap but need more than a pattern copy (missing ingest command / missing format bridge) — tracked in the 2026-07-15 wiring audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)