### PR TITLE
fix(deploy): use GITHUB_TOKEN instead of expired MADFAM_BOT_PAT

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -54,15 +54,13 @@ jobs:
           fi
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          token: ${{ secrets.MADFAM_BOT_PAT }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.MADFAM_BOT_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -58,15 +58,13 @@ jobs:
           fi
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          token: ${{ secrets.MADFAM_BOT_PAT }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.MADFAM_BOT_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -54,15 +54,13 @@ jobs:
           fi
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          token: ${{ secrets.MADFAM_BOT_PAT }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.MADFAM_BOT_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
All three deploy workflows fail at `Checkout` since ~2026-07-10 (expired `MADFAM_BOT_PAT`, issue #148) — prod is frozen on pre-07-10 images. Nothing in these workflows actually needs a PAT:

- **Checkout + digest-commit push**: same-repo, `main` has no branch protection, job has `contents: write`. Default persisted credentials suffice. Bonus: `GITHUB_TOKEN` pushes don't re-trigger workflows → digest commits stop burning a full CI run each (ArgoCD polls git, unaffected).
- **GHCR push**: job has `packages: write`.

Cosign keyless signing is OIDC (`id-token: write`) — the Kyverno verify-signature subject is the workflow identity, not the actor — unaffected. The cluster's `ghcr-credentials` pull secret is separate and untouched.

This removes the deploy pipeline's dependency on a rotating personal token entirely. If the GHCR package isn't repo-linked for `GITHUB_TOKEN` pushes we'll see a 403 on the first run and can fall back — but the empirical test is one dispatch away.

Note: web/admin deploys additionally need a valid `NPM_MADFAM_TOKEN` build-arg for `npm ci` inside the image build — that rotation is still pending; this PR unblocks the **API** deploy immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)