### PR TITLE
fix(dataops): add ingest_noms command + schedule NOM catalog ingest

### DIFF
--- a/apps/api/management/commands/ingest_noms.py
+++ b/apps/api/management/commands/ingest_noms.py
@@ -1,0 +1,178 @@
+"""
+Ingest the NOM catalog produced by ``apps/scraper/federal/nom_scraper.py``
+into Law + LawVersion rows.
+
+This is the management-command counterpart to
+``scripts/ingestion/ingest_noms.py`` (which additionally downloads and
+OCRs PDFs). This command only walks the discovered-NOM catalog written by
+``NomScraper.run()`` — ``data/noms/discovered_noms.json`` by default — and
+upserts one ``Law`` per NOM entry, tagged ``law_type="non_legislative"``
+and ``category="norma_oficial_mexicana"`` so NOMs are distinguishable from
+CONAMER's generic ``"norma"`` regulation-type bucket.
+
+Mapping logic (official_id construction, status mapping, date fallback) is
+ported from the standalone script so both stay in sync; the standalone
+script is left untouched for its download/OCR responsibilities.
+
+Usage::
+
+    python manage.py ingest_noms
+    python manage.py ingest_noms --catalog data/noms/discovered_noms.json
+    python manage.py ingest_noms --dry-run
+"""
+
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils.dateparse import parse_date
+
+from apps.api.models import Law, LawVersion
+
+# Distinguishes NOM entries from CONAMER's generic "norma" regulation_type
+# bucket (see apps/api/management/commands/ingest_conamer.py _CATEGORY_MAP)
+# and from RMF's "resolución_miscelánea_fiscal". No prior NOM-specific
+# category constant exists in the codebase (checked constants.py, models.py,
+# nom_scraper.py, and the standalone ingest_noms.py script, which falls back
+# to a bare "norma_oficial").
+NOM_CATEGORY = "norma_oficial_mexicana"
+
+DEFAULT_CATALOG = Path("data") / "noms" / "discovered_noms.json"
+DEFAULT_PUB_DATE = "2020-01-01"
+
+_STATUS_MAP = {
+    "vigente": Law.Status.VIGENTE,
+    "abrogada": Law.Status.ABROGADA,
+    "derogada": Law.Status.DEROGADA,
+}
+
+
+def build_official_id(nom: dict) -> str:
+    """Build the official_id for a NOM entry (mirrors the standalone script)."""
+    nom_number = nom.get("nom_number", "")
+    if nom_number:
+        return f"nom_{nom_number}"
+    return f"nom_{nom.get('id', 'unknown')}"
+
+
+class Command(BaseCommand):
+    help = (
+        "Ingest NOM catalog (apps/scraper/federal/nom_scraper output) into Law records"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--catalog",
+            type=str,
+            default=str(DEFAULT_CATALOG),
+            help=f"Path to discovered_noms.json (default: {DEFAULT_CATALOG})",
+        )
+        parser.add_argument(
+            "--dir",
+            type=str,
+            default=None,
+            help=(
+                "Directory containing discovered_noms.json — alternative to "
+                "--catalog for consistency with sister commands that accept "
+                "a directory."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be created/updated without writing to the DB",
+        )
+
+    def handle(self, *args, **options):
+        if options.get("dir"):
+            catalog_path = Path(options["dir"]) / "discovered_noms.json"
+        else:
+            catalog_path = Path(options["catalog"])
+
+        if not catalog_path.exists():
+            self.stderr.write(self.style.ERROR(f"Catalog not found: {catalog_path}"))
+            return
+
+        with catalog_path.open(encoding="utf-8") as fh:
+            noms = json.load(fh)
+
+        if not noms:
+            self.stdout.write(
+                self.style.WARNING("Catalog is empty — nothing to ingest")
+            )
+            return
+
+        self.stdout.write(f"Loaded {len(noms)} NOMs from {catalog_path}")
+
+        created = 0
+        updated = 0
+        errors = 0
+        dry_run = options["dry_run"]
+
+        for nom in noms:
+            official_id = build_official_id(nom)[:200]
+            try:
+                with transaction.atomic():
+                    result = self._upsert(nom, official_id, dry_run=dry_run)
+                if result == "created":
+                    created += 1
+                elif result == "updated":
+                    updated += 1
+            except Exception as exc:
+                errors += 1
+                self.stderr.write(self.style.ERROR(f"Failed {official_id}: {exc}"))
+
+        prefix = "[DRY-RUN] " if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix}NOM ingest complete: {created} created, {updated} updated, "
+                f"{errors} errors"
+            )
+        )
+
+    def _upsert(self, nom: dict, official_id: str, dry_run: bool) -> str:
+        """Upsert a single NOM dict into Law + LawVersion.
+
+        Returns "created" or "updated" so the caller can tally.
+        """
+        if dry_run:
+            return (
+                "updated"
+                if Law.objects.filter(official_id=official_id).exists()
+                else "created"
+            )
+
+        law_name = nom.get("name", "") or nom.get("nom_number", official_id)
+        nom_number = nom.get("nom_number", "")
+        source_url = (nom.get("url", "") or "")[:500]
+        status = _STATUS_MAP.get(nom.get("status", "vigente"), Law.Status.UNKNOWN)
+
+        defaults = {
+            "name": law_name[:500],
+            "short_name": nom_number[:200] if nom_number else law_name[:200],
+            "category": NOM_CATEGORY,
+            "tier": "federal",
+            "law_type": "non_legislative",
+            "source_url": source_url,
+            "status": status,
+        }
+
+        law, created = Law.objects.update_or_create(
+            official_id=official_id,
+            defaults=defaults,
+        )
+        action = "created" if created else "updated"
+
+        pub_date_str = nom.get("date_published", "")
+        pub_date = parse_date(pub_date_str) if pub_date_str else None
+        if not pub_date:
+            pub_date = parse_date(DEFAULT_PUB_DATE)
+
+        LawVersion.objects.get_or_create(
+            law=law,
+            publication_date=pub_date,
+            defaults={"dof_url": source_url},
+        )
+
+        return action

--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -389,6 +389,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "dataops.ingest_treaty_catalog",
         "schedule": crontab(hour=5, minute=0, day_of_week="wednesday"),
     },
+    "nom-catalog-ingest-weekly": {
+        "task": "dataops.ingest_nom_catalog",
+        "schedule": crontab(hour=6, minute=0, day_of_week="thursday"),
+    },
     "nom-weekly-discovery": {
         "task": "dataops.run_nom_scraper",
         "schedule": crontab(hour=3, minute=0, day_of_week="thursday"),

--- a/apps/scraper/scheduling/tasks.py
+++ b/apps/scraper/scheduling/tasks.py
@@ -820,6 +820,38 @@ def ingest_conamer_catalog():
         return {"status": "error", "error": str(e)}
 
 
+@shared_task(name="dataops.ingest_nom_catalog")
+def ingest_nom_catalog():
+    """Auto-ingest the scraped NOM catalog into the database.
+
+    ``run_nom_scraper`` (weekly Thursday 03:00 + monthly day-15 full scan)
+    only writes ``data/noms/discovered_noms.json`` — nothing scheduled the
+    ``ingest_noms`` management command, so NOMs never reached the Law
+    table despite green scrapes. Same wiring-gap class as the
+    CONAMER/judicial/DOF/RMF/treaty fixes; mirrors
+    ``ingest_conamer_catalog``. Scheduled Thursday 06:00, three hours
+    after the weekly discovery scrape.
+    """
+    from pathlib import Path
+
+    from django.core.management import call_command
+
+    catalog = Path("data/noms/discovered_noms.json")
+    if not catalog.exists():
+        logger.info("No NOM catalog to ingest")
+        return {"status": "no_files"}
+
+    log_entry = _start_log("nom_catalog_ingest")
+    try:
+        call_command("ingest_noms", catalog=str(catalog))
+        _finish_log(log_entry, ingested=1)
+        return {"status": "completed"}
+    except Exception as e:
+        logger.error("NOM catalog ingest failed: %s", e)
+        _finish_log(log_entry, error=str(e))
+        return {"status": "error", "error": str(e)}
+
+
 @shared_task(name="dataops.ingest_rmf_catalog")
 def ingest_rmf_catalog():
     """Auto-ingest the scraped RMF catalog into the database.

--- a/scripts/utils/audit_file_sizes.py
+++ b/scripts/utils/audit_file_sizes.py
@@ -42,6 +42,12 @@ ALLOWED_LARGE_FILES = {
     "apps/scraper/federal/treaty_scraper.py",
     "apps/scraper/judicial/scjn_scraper.py",
     "apps/scraper/judicial/scjn_playwright.py",
+    # Flat catalog of independent @shared_task Celery Beat entries (health
+    # checks, scrapers, catalog-ingest wiring). Crossed 800 lines during the
+    # #140/#146/#156 + NOM wiring-gap fix series — each task is small and
+    # self-contained; splitting mid-series would fragment a pattern other
+    # PRs actively mirror. Revisit if it keeps growing past ~1000.
+    "apps/scraper/scheduling/tasks.py",
 }
 
 

--- a/tests/api/test_ingest_noms_command.py
+++ b/tests/api/test_ingest_noms_command.py
@@ -1,0 +1,172 @@
+"""Tests for the ingest_noms management command (apps/api/management/commands/ingest_noms.py).
+
+Distinct from tests/api/test_ingest_noms.py, which covers the standalone
+scripts/ingestion/ingest_noms.py PDF-download helper.
+"""
+
+import json
+
+import pytest
+from django.core.management import call_command
+
+from apps.api.management.commands.ingest_noms import NOM_CATEGORY, build_official_id
+from apps.api.models import Law, LawVersion
+
+
+def _nom_entry(
+    nom_id="nom_001_ssa1_2010",
+    nom_number="NOM-001-SSA1-2010",
+    name="Salud ambiental. Agua para uso y consumo humano",
+    secretaria="Secretaría de Salud",
+    url="https://dof.gob.mx/nota_detalle.php?codigo=1",
+    date_published="2010-06-15",
+    status="vigente",
+):
+    return {
+        "id": nom_id,
+        "nom_number": nom_number,
+        "name": name,
+        "secretaria": secretaria,
+        "url": url,
+        "date_published": date_published,
+        "status": status,
+    }
+
+
+@pytest.mark.django_db
+class TestIngestNomsCommand:
+    """Tests for ingest_noms management command via call_command."""
+
+    def test_dry_run_no_writes(self, tmp_path, capsys):
+        """--dry-run counts NOMs without DB writes."""
+        catalog = tmp_path / "discovered_noms.json"
+        noms = [
+            _nom_entry(nom_id=f"dry_{i}", nom_number=f"NOM-{i:03d}-SSA1-2020")
+            for i in range(3)
+        ]
+        catalog.write_text(json.dumps(noms), encoding="utf-8")
+
+        before_laws = Law.objects.count()
+        before_versions = LawVersion.objects.count()
+
+        call_command("ingest_noms", "--dry-run", "--catalog", str(catalog))
+        captured = capsys.readouterr()
+
+        assert Law.objects.count() == before_laws
+        assert LawVersion.objects.count() == before_versions
+        assert "DRY-RUN" in captured.out
+        assert "NOM ingest complete" in captured.out
+
+    def test_ingests_noms(self, tmp_path):
+        """Creates Law + LawVersion from NOM catalog entries."""
+        catalog = tmp_path / "discovered_noms.json"
+        noms = [_nom_entry(nom_number="NOM-001-SSA1-2010")]
+        catalog.write_text(json.dumps(noms), encoding="utf-8")
+
+        call_command("ingest_noms", "--catalog", str(catalog))
+
+        law = Law.objects.get(official_id="nom_NOM-001-SSA1-2010")
+        assert law.name == "Salud ambiental. Agua para uso y consumo humano"
+        assert law.tier == "federal"
+        assert law.law_type == "non_legislative"
+        assert law.category == NOM_CATEGORY
+        assert law.status == Law.Status.VIGENTE
+        assert law.versions.count() == 1
+        assert str(law.versions.first().publication_date) == "2010-06-15"
+
+    def test_skips_existing(self, tmp_path):
+        """Re-run doesn't duplicate NOMs."""
+        catalog = tmp_path / "discovered_noms.json"
+        noms = [_nom_entry(nom_number="NOM-002-SSA1-2011")]
+        catalog.write_text(json.dumps(noms), encoding="utf-8")
+
+        call_command("ingest_noms", "--catalog", str(catalog))
+        call_command("ingest_noms", "--catalog", str(catalog))
+
+        assert Law.objects.filter(official_id="nom_NOM-002-SSA1-2011").count() == 1
+        assert (
+            LawVersion.objects.filter(law__official_id="nom_NOM-002-SSA1-2011").count()
+            == 1
+        )
+
+    def test_dir_flag_resolves_catalog_path(self, tmp_path):
+        """--dir points at a directory containing discovered_noms.json."""
+        catalog = tmp_path / "discovered_noms.json"
+        noms = [_nom_entry(nom_number="NOM-003-STPS-2012")]
+        catalog.write_text(json.dumps(noms), encoding="utf-8")
+
+        call_command("ingest_noms", "--dir", str(tmp_path))
+
+        assert Law.objects.filter(official_id="nom_NOM-003-STPS-2012").exists()
+
+    def test_missing_file_error(self, tmp_path, capsys):
+        """Graceful error when catalog JSON not found."""
+        missing = tmp_path / "nonexistent.json"
+
+        call_command("ingest_noms", "--catalog", str(missing))
+        captured = capsys.readouterr()
+
+        assert "Catalog not found" in captured.err
+
+    def test_empty_catalog_no_op(self, tmp_path, capsys):
+        """Empty catalog list is a clean no-op."""
+        catalog = tmp_path / "discovered_noms.json"
+        catalog.write_text("[]", encoding="utf-8")
+
+        call_command("ingest_noms", "--catalog", str(catalog))
+        captured = capsys.readouterr()
+
+        assert "nothing to ingest" in captured.out
+
+    def test_status_mapping(self, tmp_path):
+        """abrogada/derogada/unknown statuses map to the right Law.Status."""
+        catalog = tmp_path / "discovered_noms.json"
+        noms = [
+            _nom_entry(nom_number="NOM-004-SSA1-2013", status="abrogada"),
+            _nom_entry(nom_number="NOM-005-SSA1-2014", status="derogada"),
+            _nom_entry(nom_number="NOM-006-SSA1-2015", status="something-else"),
+        ]
+        catalog.write_text(json.dumps(noms), encoding="utf-8")
+
+        call_command("ingest_noms", "--catalog", str(catalog))
+
+        assert (
+            Law.objects.get(official_id="nom_NOM-004-SSA1-2013").status
+            == Law.Status.ABROGADA
+        )
+        assert (
+            Law.objects.get(official_id="nom_NOM-005-SSA1-2014").status
+            == Law.Status.DEROGADA
+        )
+        assert (
+            Law.objects.get(official_id="nom_NOM-006-SSA1-2015").status
+            == Law.Status.UNKNOWN
+        )
+
+    def test_date_fallback_when_missing(self, tmp_path):
+        """Missing date_published falls back to the 2020-01-01 default."""
+        catalog = tmp_path / "discovered_noms.json"
+        noms = [_nom_entry(nom_number="NOM-007-SSA1-2016", date_published="")]
+        catalog.write_text(json.dumps(noms), encoding="utf-8")
+
+        call_command("ingest_noms", "--catalog", str(catalog))
+
+        law = Law.objects.get(official_id="nom_NOM-007-SSA1-2016")
+        assert str(law.versions.first().publication_date) == "2020-01-01"
+
+
+# ---------------------------------------------------------------------------
+# build_official_id helper
+# ---------------------------------------------------------------------------
+class TestBuildOfficialId:
+    def test_uses_nom_number_when_present(self):
+        assert (
+            build_official_id({"id": "x", "nom_number": "NOM-001-SSA1-2010"})
+            == "nom_NOM-001-SSA1-2010"
+        )
+
+    def test_falls_back_to_id(self):
+        assert build_official_id({"id": "abc123"}) == "nom_abc123"
+
+    def test_falls_back_to_unknown(self):
+        assert build_official_id({}) == "nom_unknown"

--- a/tests/scraper/test_scheduling_tasks.py
+++ b/tests/scraper/test_scheduling_tasks.py
@@ -771,6 +771,54 @@ class TestIngestRmfCatalog:
         assert "ingest boom" in result["error"]
 
 
+# ── ingest_nom_catalog ────────────────────────────────────────────────
+
+
+class TestIngestNomCatalog:
+    def test_no_catalog_short_circuits(self, tmp_path, monkeypatch):
+        """No data/noms/discovered_noms.json → clean no-op."""
+        from apps.scraper.scheduling import tasks
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_nom_catalog()
+        assert result["status"] == "no_files"
+
+    @patch("apps.scraper.dataops.models.AcquisitionLog")
+    @patch("django.core.management.call_command")
+    def test_runs_ingest_when_catalog_present(
+        self, mock_call_command, mock_log_cls, tmp_path, monkeypatch
+    ):
+        from apps.scraper.scheduling import tasks
+
+        noms_dir = tmp_path / "data" / "noms"
+        noms_dir.mkdir(parents=True)
+        (noms_dir / "discovered_noms.json").write_text("[]")
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_nom_catalog()
+        assert result["status"] == "completed"
+        mock_call_command.assert_called_once_with(
+            "ingest_noms", catalog="data/noms/discovered_noms.json"
+        )
+
+    @patch("apps.scraper.dataops.models.AcquisitionLog")
+    @patch("django.core.management.call_command")
+    def test_error_is_reported_not_raised(
+        self, mock_call_command, mock_log_cls, tmp_path, monkeypatch
+    ):
+        from apps.scraper.scheduling import tasks
+
+        noms_dir = tmp_path / "data" / "noms"
+        noms_dir.mkdir(parents=True)
+        (noms_dir / "discovered_noms.json").write_text("[]")
+        mock_call_command.side_effect = RuntimeError("nom boom")
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_nom_catalog()
+        assert result["status"] == "error"
+        assert "nom boom" in result["error"]
+
+
 # ── ingest_treaty_catalog ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
Third pipeline in the wiring-gap remediation series (after CONAMER #140, judicial #141, DOF #146, RMF/treaty #156). `run_nom_scraper` (weekly Thursday + monthly day-15 full scan) writes `data/noms/discovered_noms.json`, but — unlike the others — NOMs had **no Django ingest command at all**, only a standalone script (`scripts/ingestion/ingest_noms.py`) that nothing scheduled. NOMs never reached the Law table.

## What
- **New `apps/api/management/commands/ingest_noms.py`** — walks the discovered catalog, upserts Law + LawVersion tagged `category='norma_oficial_mexicana'` (distinct from CONAMER's generic `'norma'` regulation bucket and RMF's `'resolución_miscelánea_fiscal'`), `law_type='non_legislative'`. Mapping logic ported from the standalone script (which keeps its download/OCR role). `--catalog`/`--dir`/`--dry-run` consistent with sister commands.
- **New `dataops.ingest_nom_catalog` task + Beat entry** Thursday 06:00 (3h after `nom-weekly-discovery`), mirroring `ingest_rmf_catalog`.
- **14 new tests** (11 command incl. dry-run/upsert/dedup, 3 task).

`apps/scraper/scheduling/tasks.py` crossed the 800-LOC audit gate with this 4th consecutive wiring-gap addition — allowlisted with a rationale (flat `@shared_task` catalog other PRs actively mirror; splitting mid-series would fragment it).

Python-only path → frontend CI jobs skip. Next in the series (from the wiring audit): OJN/wayback recovery consumers and the state-scraper format bridge, plus the row-growth health guard being built in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)