### PR TITLE
docs(dataops): descope OJN/wayback recovery pipelines from auto-ingest

### DIFF
--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -439,6 +439,13 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(hour=22, minute=0, day_of_week="saturday"),
         "kwargs": {"max_items": 5000, "epoca": 11, "tipo": "jurisprudencia"},
     },
+    # DESCOPED from auto-ingest (2026-07-16 wiring audit): both recovery
+    # scripts below write raw, unparsed files (PDF/DOC/HTML) — not a
+    # structured catalog an existing ingest_* command can parse — and never
+    # touch GapRecord. No text-extraction/official_id-derivation step exists
+    # to bridge them into the Law table with MVP-sized glue, unlike the
+    # CONAMER/NOM/RMF/treaty catalogs. Output is consumed manually; see the
+    # task docstrings in apps/scraper/scheduling/tasks.py for details.
     "ojn-recovery-monthly": {
         "task": "dataops.run_ojn_recovery",
         "schedule": crontab(hour=3, minute=0, day_of_month="10"),

--- a/apps/scraper/scheduling/tasks.py
+++ b/apps/scraper/scheduling/tasks.py
@@ -610,6 +610,20 @@ def run_ojn_recovery(paths="ab", scope="all", limit=500):
         paths: Recovery paths to run ("a", "ab", "abc")
         scope: "non_leg", "leg", or "all"
         limit: Max items per path
+
+    Output is NOT auto-ingested. ``ojn_multipath_recovery.py`` writes raw
+    PDF/DOC binaries to ``data/recovery/{path_a,path_b}/{state}/`` plus JSON
+    reports (``recovery_report.json``, ``recovered_records.json``,
+    ``remaining_failures.json``) to ``data/recovery/`` — it does not extract
+    text, derive an ``official_id``, or update ``state_laws_metadata.json``
+    or any ``GapRecord`` row. Unlike the CONAMER/NOM/RMF/treaty catalogs
+    (structured JSON an ``ingest_*`` command already parses), these are raw
+    research artifacts with no existing text-extraction step, so there is no
+    minimal-glue ingest path today. Consumed manually: an operator reviews
+    ``data/recovery/recovery_report.json``, cross-checks recovered files
+    against the original gap, and re-runs the normal state-law pipeline
+    (extract → parse → ``ingest_state_laws``) by hand for anything worth
+    keeping. Revisit if/when a recovered-file → pipeline bridge is built.
     """
     import subprocess
 
@@ -646,6 +660,18 @@ def run_wayback_recovery(domains=None, limit=200):
     Args:
         domains: List of domains (None = all configured)
         limit: Max records per domain
+
+    Output is NOT auto-ingested. ``wayback_bulk_recovery.py`` writes raw
+    PDF/DOC/HTML/JSON files to ``data/wayback_recovery/<domain>/`` plus
+    ``wayback_recovery_report.json`` — it does not extract text, derive an
+    ``official_id``, or update any ``GapRecord`` row. These are undifferentiated
+    archive dumps from dead domains (sinec.gob.mx, cnartys.conamer.gob.mx,
+    etc.), not a structured catalog an existing ``ingest_*`` command can
+    parse, so there is no minimal-glue ingest path today. Consumed manually:
+    an operator reviews ``data/wayback_recovery/wayback_recovery_report.json``,
+    triages downloaded files per domain, and feeds anything worth keeping
+    through the normal extract → parse → ingest pipeline by hand. Revisit if
+    a recovered-file → pipeline bridge is built.
     """
     import subprocess
 


### PR DESCRIPTION
Closes the last two ORPHANED entries from the 2026-07-15 wiring audit — with a **descope verdict**, not glue, based on reading both scripts end-to-end:

- `ojn_multipath_recovery.py` and `wayback_bulk_recovery.py` write **raw PDF/DOC/HTML binaries** + JSON reports. No text extraction, no `official_id` derivation, no `GapRecord` interaction — nothing an existing `ingest_*` command can parse. Bridging raw binaries into Law/LawVersion would be a new extraction feature, not MVP wiring (unlike the CONAMER/NOM/RMF/treaty cases, which all had structured catalogs + existing ingest commands).
- Both task docstrings now state explicitly that output is **not auto-ingested** and describe the manual triage path; the Beat entries carry the same annotation so future wiring audits don't re-flag them as false-positive orphans.
- Scripts keep their manual-triage value; nothing disabled.

Docs/comments only — `TestRecoveryTasks` (4 tests) unaffected; scheduling suite 60 passed. All quality gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)