### PR TITLE
fix(dataops): bridge state-scraper catalogs into the Law table

### DIFF
--- a/apps/api/management/commands/ingest_state_catalogs.py
+++ b/apps/api/management/commands/ingest_state_catalogs.py
@@ -1,0 +1,206 @@
+"""
+Ingest state congress scraper catalogs (apps/scraper/state/*.py output) into
+Law records.
+
+``run_state_scraper`` (apps/scraper/scheduling/tasks.py) writes a bare
+catalog — ``name``/``url``/``state``/``tier``/``category``/``law_type`` —
+to ``data/state_laws/<state_key>/catalog.json``. None of the 14 registered
+state scrapers download law text (``scrape_law_content`` exists on the base
+class but is never invoked by the scheduled task), so the rich
+``state_laws_metadata.json`` format that ``ingest_state_laws`` expects
+(``official_id``, ``text_file``, ``akn_file_path``, ``publication_date``)
+never gets produced from this pipeline.
+
+This command bridges the gap at the level the scrapers actually support:
+it upserts one ``Law`` per discovered catalog entry directly from
+``catalog.json``, with ``tier="state"`` and no ``LawVersion`` (there is no
+law text to attach yet). This gets discovery into the DB so the row-growth
+guard can see it; full-text ingestion remains a separate, future pipeline
+that would need the scrapers to actually download and store law documents.
+
+Usage::
+
+    python manage.py ingest_state_catalogs --state guerrero
+    python manage.py ingest_state_catalogs --all
+    python manage.py ingest_state_catalogs --all --dry-run
+"""
+
+import json
+import re
+import unicodedata
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from apps.api.models import Law
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+STATE_LAWS_ROOT = PROJECT_ROOT / "data" / "state_laws"
+
+
+def _strip_accents(text: str) -> str:
+    """Remove diacritical marks from text."""
+    nfkd = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in nfkd if not unicodedata.combining(ch))
+
+
+def _slugify(text: str) -> str:
+    """Create a safe slug from a law name (mirrors ingest_conamer/ingest_treaties)."""
+    text = _strip_accents(text.lower().strip())
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "_", text)
+    return text[:150]
+
+
+def build_official_id(state_key: str, entry: dict) -> str:
+    """Build a stable official_id from the state key and law name/URL.
+
+    Catalog entries have no upstream ID (unlike NOMs or treaties), so the
+    slug is derived from the law name. Falls back to a slug of the URL if
+    the name is missing, since ``name`` and ``url`` are both required by
+    ``StateCongressScraper.validate_law_data``.
+    """
+    name = entry.get("name") or entry.get("url", "")
+    return f"state_{state_key}_{_slugify(name)}"[:200]
+
+
+class Command(BaseCommand):
+    help = (
+        "Ingest state congress scraper catalogs "
+        "(data/state_laws/<state>/catalog.json) into Law records"
+    )
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            "--all", action="store_true", help="Ingest catalogs for every state"
+        )
+        group.add_argument(
+            "--state", type=str, help="Ingest a single state (e.g. guerrero)"
+        )
+
+        parser.add_argument(
+            "--dry-run", action="store_true", help="Show counts without writing to DB"
+        )
+        parser.add_argument(
+            "--state-laws-root",
+            type=str,
+            default=str(STATE_LAWS_ROOT),
+            help=f"Root directory containing per-state catalog.json files "
+            f"(default: {STATE_LAWS_ROOT})",
+        )
+
+    def handle(self, *args, **options):
+        state_laws_root = Path(options["state_laws_root"])
+
+        if options["state"]:
+            catalogs = [
+                (options["state"], state_laws_root / options["state"] / "catalog.json")
+            ]
+        else:
+            if not state_laws_root.exists():
+                self.stdout.write(
+                    self.style.ERROR(f"No state catalogs found under {state_laws_root}")
+                )
+                return
+            catalogs = sorted(
+                (path.parent.name, path)
+                for path in state_laws_root.glob("*/catalog.json")
+            )
+
+        catalogs = [(key, path) for key, path in catalogs if path.exists()]
+        if not catalogs:
+            self.stdout.write(self.style.ERROR("No catalog.json files found to ingest"))
+            return
+
+        dry_run = options["dry_run"]
+        total_created = 0
+        total_updated = 0
+        total_errors = 0
+        total_entries = 0
+
+        for state_key, catalog_path in catalogs:
+            with catalog_path.open(encoding="utf-8") as fh:
+                entries = json.load(fh)
+
+            if not entries:
+                self.stdout.write(f"{state_key}: catalog empty, skipping")
+                continue
+
+            total_entries += len(entries)
+            self.stdout.write(
+                f"{state_key}: {len(entries)} entries from {catalog_path}"
+            )
+
+            created = 0
+            updated = 0
+            errors = 0
+
+            for entry in entries:
+                official_id = build_official_id(state_key, entry)
+                try:
+                    with transaction.atomic():
+                        result = self._upsert(state_key, entry, official_id, dry_run)
+                    if result == "created":
+                        created += 1
+                    elif result == "updated":
+                        updated += 1
+                except Exception as exc:
+                    errors += 1
+                    self.stderr.write(self.style.ERROR(f"Failed {official_id}: {exc}"))
+
+            prefix = "[DRY-RUN] " if dry_run else ""
+            self.stdout.write(
+                f"  {prefix}{state_key}: {created} created, {updated} updated, "
+                f"{errors} errors"
+            )
+            total_created += created
+            total_updated += updated
+            total_errors += errors
+
+        self.stdout.write("")
+        prefix = "[DRY-RUN] " if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix}State catalog ingest complete: {total_entries} entries, "
+                f"{total_created} created, {total_updated} updated, "
+                f"{total_errors} errors"
+            )
+        )
+
+    def _upsert(
+        self, state_key: str, entry: dict, official_id: str, dry_run: bool
+    ) -> str:
+        """Upsert a single catalog entry into Law. Returns "created" or "updated"."""
+        if dry_run:
+            return (
+                "updated"
+                if Law.objects.filter(official_id=official_id).exists()
+                else "created"
+            )
+
+        law_name = (entry.get("name") or "")[:2000]
+        state_name = entry.get("state") or state_key.replace("_", " ").title()
+        source_url = (entry.get("url", "") or "")[:500]
+        category = entry.get("category") or "Otro"
+
+        # Base scraper law_type values (ley, codigo, decreto...) don't match
+        # Law.LawType choices (legislative/non_legislative) — catalog entries
+        # are always legislative-branch documents (laws, codes, decrees), so
+        # normalize to the model's choice field instead of passing the
+        # scraper's finer-grained classification straight through.
+        defaults = {
+            "name": law_name,
+            "tier": "state",
+            "category": category,
+            "state": state_name,
+            "source_url": source_url,
+            "law_type": Law.LawType.LEGISLATIVE,
+        }
+
+        _, created = Law.objects.update_or_create(
+            official_id=official_id,
+            defaults=defaults,
+        )
+        return "created" if created else "updated"

--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -427,6 +427,13 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(hour=2, minute=30, day_of_month="5"),
         "kwargs": {"state_key": "nuevo_leon"},
     },
+    # Ingest a few hours after the monthly state scraper runs above — the
+    # scraped catalogs previously had no scheduled consumer (wiring-gap
+    # class; see ingest_conamer_catalog / ingest_nom_catalog).
+    "state-catalog-ingest-monthly": {
+        "task": "dataops.ingest_state_catalogs",
+        "schedule": crontab(hour=5, minute=0, day_of_month="5"),
+    },
     # ── Phase 16: SCJN judicial corpus ────────────────────────────────
     "scjn-weekly-scrape": {
         "task": "dataops.scrape_scjn",

--- a/apps/scraper/scheduling/tasks.py
+++ b/apps/scraper/scheduling/tasks.py
@@ -930,6 +930,42 @@ def ingest_treaty_catalog():
         return {"status": "error", "error": str(e)}
 
 
+@shared_task(name="dataops.ingest_state_catalogs")
+def ingest_state_catalogs():
+    """Auto-ingest scraped state-congress catalogs into the database.
+
+    ``run_state_scraper`` writes a bare catalog (name/url/state/tier/
+    category/law_type — no law text) to
+    ``data/state_laws/<state>/catalog.json`` for each state key it runs.
+    Nothing consumed that output: ``ingest_state_laws`` reads a completely
+    different, richer artifact (``state_laws_metadata.json``, with
+    ``text_file``/``akn_file_path``/``publication_date``) that the state
+    scrapers never produce, so scraped catalogs were a dead end even for
+    manual ingestion. This ingests catalog.json directly — one Law row per
+    discovered entry, tier="state", no LawVersion since there's no law text
+    to attach yet. Mirrors ``ingest_conamer_catalog``; scheduled a few
+    hours after the monthly state scraper runs (day 5).
+    """
+    from pathlib import Path
+
+    from django.core.management import call_command
+
+    state_laws_root = Path("data/state_laws")
+    if not state_laws_root.exists() or not list(state_laws_root.glob("*/catalog.json")):
+        logger.info("No state catalogs to ingest")
+        return {"status": "no_files"}
+
+    log_entry = _start_log("state_catalog_ingest")
+    try:
+        call_command("ingest_state_catalogs", all=True)
+        _finish_log(log_entry, ingested=1)
+        return {"status": "completed"}
+    except Exception as e:
+        logger.error("State catalog ingest failed: %s", e)
+        _finish_log(log_entry, error=str(e))
+        return {"status": "error", "error": str(e)}
+
+
 @shared_task(name="dataops.classify_law_domains")
 def classify_law_domains_task():
     """Weekly domain classification for newly added laws."""

--- a/tests/api/test_ingest_state_catalogs_command.py
+++ b/tests/api/test_ingest_state_catalogs_command.py
@@ -1,0 +1,175 @@
+"""Tests for the ingest_state_catalogs management command
+(apps/api/management/commands/ingest_state_catalogs.py).
+
+Covers the bridge from the bare state-congress scraper catalog
+(name/url/state/tier/category/law_type, no law text) into Law rows.
+"""
+
+import json
+
+import pytest
+from django.core.management import call_command
+
+from apps.api.management.commands.ingest_state_catalogs import build_official_id
+from apps.api.models import Law, LawVersion
+
+
+def _catalog_entry(
+    name="LEY ORGÁNICA DEL PODER LEGISLATIVO DEL ESTADO DE GUERRERO",
+    url="https://congresoguerrero.gob.mx/leyes/ley-organica",
+    state="Guerrero",
+    tier="state",
+    category="Ley Organica",
+    law_type="ley_organica",
+):
+    return {
+        "name": name,
+        "url": url,
+        "state": state,
+        "tier": tier,
+        "category": category,
+        "law_type": law_type,
+    }
+
+
+def _write_catalog(state_dir, entries):
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "catalog.json").write_text(
+        json.dumps(entries, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+@pytest.mark.django_db
+class TestIngestStateCatalogsCommand:
+    def test_dry_run_no_writes(self, tmp_path):
+        state_dir = tmp_path / "guerrero"
+        _write_catalog(
+            state_dir,
+            [_catalog_entry(), _catalog_entry(name="LEY DOS", url="https://x/2")],
+        )
+
+        before = Law.objects.count()
+
+        call_command(
+            "ingest_state_catalogs",
+            "--state",
+            "guerrero",
+            "--dry-run",
+            state_laws_root=str(tmp_path),
+        )
+
+        assert Law.objects.count() == before
+
+    def test_ingests_state_catalog(self, tmp_path):
+        state_dir = tmp_path / "guerrero"
+        _write_catalog(state_dir, [_catalog_entry()])
+
+        call_command(
+            "ingest_state_catalogs",
+            "--state",
+            "guerrero",
+            state_laws_root=str(tmp_path),
+        )
+
+        official_id = build_official_id("guerrero", _catalog_entry())
+        law = Law.objects.get(official_id=official_id)
+        assert law.name == "LEY ORGÁNICA DEL PODER LEGISLATIVO DEL ESTADO DE GUERRERO"
+        assert law.tier == "state"
+        assert law.state == "Guerrero"
+        assert law.category == "Ley Organica"
+        assert law.law_type == Law.LawType.LEGISLATIVE
+        assert law.source_url == "https://congresoguerrero.gob.mx/leyes/ley-organica"
+        # No law text available from the scraper yet — no LawVersion created.
+        assert LawVersion.objects.filter(law=law).count() == 0
+
+    def test_dedup_upserts_on_rerun(self, tmp_path):
+        state_dir = tmp_path / "guerrero"
+        entry = _catalog_entry()
+        _write_catalog(state_dir, [entry])
+
+        call_command(
+            "ingest_state_catalogs",
+            "--state",
+            "guerrero",
+            state_laws_root=str(tmp_path),
+        )
+        call_command(
+            "ingest_state_catalogs",
+            "--state",
+            "guerrero",
+            state_laws_root=str(tmp_path),
+        )
+
+        official_id = build_official_id("guerrero", entry)
+        assert Law.objects.filter(official_id=official_id).count() == 1
+
+    def test_all_flag_ingests_every_state_dir(self, tmp_path):
+        _write_catalog(tmp_path / "guerrero", [_catalog_entry()])
+        _write_catalog(
+            tmp_path / "hidalgo",
+            [
+                _catalog_entry(
+                    name="CÓDIGO CIVIL DE HIDALGO",
+                    url="https://x/hidalgo",
+                    state="Hidalgo",
+                )
+            ],
+        )
+
+        call_command("ingest_state_catalogs", "--all", state_laws_root=str(tmp_path))
+
+        assert Law.objects.filter(state="Guerrero").exists()
+        assert Law.objects.filter(state="Hidalgo").exists()
+
+    def test_missing_state_dir_no_op(self, tmp_path, capsys):
+        call_command(
+            "ingest_state_catalogs", "--state", "oaxaca", state_laws_root=str(tmp_path)
+        )
+        captured = capsys.readouterr()
+
+        assert "No catalog.json files found" in captured.out
+
+    def test_empty_catalog_skipped(self, tmp_path, capsys):
+        state_dir = tmp_path / "guerrero"
+        _write_catalog(state_dir, [])
+
+        call_command(
+            "ingest_state_catalogs",
+            "--state",
+            "guerrero",
+            state_laws_root=str(tmp_path),
+        )
+        captured = capsys.readouterr()
+
+        assert "empty, skipping" in captured.out
+        assert not Law.objects.exists()
+
+    def test_missing_name_falls_back_to_url_slug(self, tmp_path):
+        state_dir = tmp_path / "guerrero"
+        entry = _catalog_entry(
+            name="", url="https://congresoguerrero.gob.mx/doc/123.pdf"
+        )
+        _write_catalog(state_dir, [entry])
+
+        call_command(
+            "ingest_state_catalogs",
+            "--state",
+            "guerrero",
+            state_laws_root=str(tmp_path),
+        )
+
+        official_id = build_official_id("guerrero", entry)
+        assert Law.objects.filter(official_id=official_id).exists()
+
+
+class TestBuildOfficialId:
+    def test_slugifies_name_with_state_prefix(self):
+        oid = build_official_id("guerrero", {"name": "Ley Orgánica del Estado"})
+        assert oid == "state_guerrero_ley_organica_del_estado"
+
+    def test_falls_back_to_url_when_name_missing(self):
+        oid = build_official_id(
+            "hidalgo", {"name": "", "url": "https://x/ley-de-aguas"}
+        )
+        assert oid.startswith("state_hidalgo_")
+        assert "ley" in oid

--- a/tests/scraper/test_ingest_tasks.py
+++ b/tests/scraper/test_ingest_tasks.py
@@ -228,3 +228,49 @@ class TestIngestTreatyCatalog:
         result = tasks.ingest_treaty_catalog()
         assert result["status"] == "error"
         assert "treaty boom" in result["error"]
+
+
+# ── ingest_state_catalogs ─────────────────────────────────────────────
+
+
+class TestIngestStateCatalogs:
+    def test_no_catalogs_short_circuits(self, tmp_path, monkeypatch):
+        """No data/state_laws/*/catalog.json → clean no-op."""
+        from apps.scraper.scheduling import tasks
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_state_catalogs()
+        assert result["status"] == "no_files"
+
+    @patch("apps.scraper.dataops.models.AcquisitionLog")
+    @patch("django.core.management.call_command")
+    def test_runs_ingest_when_catalog_present(
+        self, mock_call_command, mock_log_cls, tmp_path, monkeypatch
+    ):
+        from apps.scraper.scheduling import tasks
+
+        state_dir = tmp_path / "data" / "state_laws" / "guerrero"
+        state_dir.mkdir(parents=True)
+        (state_dir / "catalog.json").write_text("[]")
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_state_catalogs()
+        assert result["status"] == "completed"
+        mock_call_command.assert_called_once_with("ingest_state_catalogs", all=True)
+
+    @patch("apps.scraper.dataops.models.AcquisitionLog")
+    @patch("django.core.management.call_command")
+    def test_error_is_reported_not_raised(
+        self, mock_call_command, mock_log_cls, tmp_path, monkeypatch
+    ):
+        from apps.scraper.scheduling import tasks
+
+        state_dir = tmp_path / "data" / "state_laws" / "guerrero"
+        state_dir.mkdir(parents=True)
+        (state_dir / "catalog.json").write_text("[]")
+        mock_call_command.side_effect = RuntimeError("state boom")
+
+        monkeypatch.chdir(tmp_path)
+        result = tasks.ingest_state_catalogs()
+        assert result["status"] == "error"
+        assert "state boom" in result["error"]


### PR DESCRIPTION
6th and final structural fix in the wiring-gap series (#140/#141/#146/#156/#159/#162). The 14 registered state congress scrapers write `data/state_laws/<state>/catalog.json`, but `ingest_state_laws` expects a completely different artifact (`state_laws_metadata.json` with `text_file`/`akn_file_path`) produced by an unrelated legacy bulk-download pipeline — so state scraper output was a dead end even for manual ingestion.

## Bridge shape: discovery-only ingest (evidence-based)
Verified that no state scraper downloads law text (`scrape_law_content` exists on the base class but `run_state_scraper` never calls it) — the catalogs are bare name/url/state entries. So the honest MVP bridge upserts `Law` rows directly from the catalogs (`tier='state'`, slug-based `official_id`, no `LawVersion` — no text exists yet). Discovery now lands in the DB, the row-growth guard can see all 14 states, and full-text ingestion remains a properly separate future pipeline.

## What
- New `ingest_state_catalogs` management command (`--state`/`--all`/`--dry-run`)
- New `dataops.ingest_state_catalogs` task + Beat entry (monthly day 5, 05:00 — 3h after the guerrero/nuevo_león scrapes)
- 12 new tests (9 command + 3 task, task tests in the new `test_ingest_tasks.py` home)

Rebased over #162's test-file split. Combined suites: 74 passed. All quality gates green.

This unblocks the 14→32 state-coverage push (the #1 competitive credibility gap vs vLex/Tirant): new Wave 1B scrapers now have a working end-to-end path from day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)