### PR TITLE
fix(k8s): unblock Argo sync loop + tezca-web writable ISR cache

### DIFF
--- a/k8s/production/tezca-db-backup-cronjob.yaml
+++ b/k8s/production/tezca-db-backup-cronjob.yaml
@@ -53,7 +53,11 @@ spec:
           #    MAJOR to match/exceed the server — RFC 0012: primary is PG15+).
           initContainers:
             - name: pgdump
-              image: postgres:16-alpine
+              # Fully-qualified: Kyverno restrict-image-registries matches on
+              # the literal registry prefix; bare Docker Hub shorthand is
+              # rejected at admission and this CronJob never applied (Argo
+              # stuck OutOfSync retry-looping since #145).
+              image: docker.io/library/postgres:16-alpine
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -90,7 +94,7 @@ spec:
           # 2) Upload the artifact to R2 with the AWS CLI image.
           containers:
             - name: upload
-              image: amazon/aws-cli:2.15.0
+              image: docker.io/amazon/aws-cli:2.15.0
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/k8s/production/tezca-web-deployment.yaml
+++ b/k8s/production/tezca-web-deployment.yaml
@@ -72,3 +72,18 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          # readOnlyRootFilesystem is on, but Next.js needs a writable ISR
+          # cache — without it the pod logs a continuous ENOENT storm on
+          # `mkdir .next/cache` (observed 61 restarts per web pod).
+          volumeMounts:
+            - name: next-cache
+              mountPath: /app/apps/web/.next/cache
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: next-cache
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi


### PR DESCRIPTION
Two rollout-path fixes from the enclii pre-flight sweep (full report on #148):

## 1. DB backups were never running
The #145 `tezca-db-backup` CronJob is rejected by Kyverno `restrict-image-registries` on **every** sync — bare Docker Hub shorthand (`amazon/aws-cli`, `postgres:16-alpine`) doesn't match the allowlist's literal `docker.io/` prefix. Zero CronJobs exist live in the namespace, and the `tezca-services` Argo app has been stuck OutOfSync retry-looping since 2026-07-10. Fully-qualifying both images fixes admission, lands the backup job, and lets the app reach Synced/Healthy.

## 2. tezca-web restart churn (61 per pod)
`readOnlyRootFilesystem: true` with no writable volumes → continuous `ENOENT: mkdir .next/cache` storm from Next.js ISR. Adds emptyDir mounts for `.next/cache` (256Mi) and `/tmp` (64Mi).

Both apply via ArgoCD auto-sync on merge; **neither depends on the GHCR package linkage**, so this cleans the rollout path in advance.

YAML validated; k8s-path change only (frontend/backend CI jobs skip via path filters — NetworkPolicy consistency check runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)