### PR TITLE
fix(deploy): publish API image to a fresh repo-linked package

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -26,7 +26,12 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: madfam-org/tezca/api
+  # Fresh package name: the legacy madfam-org/tezca/api package was created
+  # by PAT pushes and its Actions-access ACL rejects GITHUB_TOKEN (403, and
+  # the ACL is UI-only). A package first published BY a workflow is
+  # automatically repo-linked with write access — no ACL surgery needed.
+  IMAGE_NAME: madfam-org/tezca-api
+  LEGACY_IMAGE_NAME: madfam-org/tezca/api
 
 concurrency:
   group: tezca-production-kustomization
@@ -106,7 +111,7 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             cd k8s/production
-            kustomize edit set image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}
+            kustomize edit set image ${{ env.REGISTRY }}/${{ env.LEGACY_IMAGE_NAME }}=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}
             cd ../..
             git add k8s/production/kustomization.yaml
             git diff --staged --quiet && echo "No changes to commit" && exit 0


### PR DESCRIPTION
The legacy `ghcr.io/madfam-org/tezca/api` package was created by PAT pushes; its Actions-access ACL rejects `GITHUB_TOKEN` (403 — verified again just now) and that ACL is **UI-only**. GitHub's documented behavior: a package **first published by a workflow** is automatically linked to the repository with write access.

So: publish to `ghcr.io/madfam-org/tezca-api` (fresh, flat name). The digest-commit step maps the manifests' legacy image reference to the new package via the kustomization images transform — which atomically carries `tezca-beat` and `tezca-worker` too (same image).

**Pull-side note:** the new package will be created private; the cluster's `ghcr-credentials` validity is unverified. RollingUpdate keeps current pods serving if the pull fails — the rollout attempt is itself the test, and the one-click fallback (make the new package public — repo is AGPL) is trivially available.

Legacy packages stay untouched. Web/admin get the same treatment when their NPM-token gate clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)