### PR TITLE
feat(k8s): one-shot RMF catch-up Job [merge = executes the scrape+ingest]

### DIFF
--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: tezca
 
 resources:
 - namespace.yaml
+- tezca-rmf-catchup-job.yaml
 - tezca-api-deployment.yaml
 - tezca-api-service.yaml
 - tezca-web-deployment.yaml

--- a/k8s/production/tezca-rmf-catchup-job.yaml
+++ b/k8s/production/tezca-rmf-catchup-job.yaml
@@ -1,0 +1,124 @@
+# One-shot catch-up: the RMF quarterly scrape ran 2026-07-08 on the old
+# (April) image whose pod-local catalog died with the 2026-07-16 rollout,
+# and the new rmf-catalog-ingest-quarterly Beat entry (day 9) missed its
+# July window — without this Job the SAT fiscal feed waits until October.
+#
+# Runs scrape → ingest for RMF, then opportunistic ingest of any other
+# catalogs present (each no-ops safely when its catalog is absent; all
+# ingests are idempotent upserts keyed on official_id).
+#
+# Lifecycle: plain GitOps Job — Argo applies it once, it runs to
+# completion and lingers Completed (no TTL: deletion would make Argo
+# recreate and re-run it). REMOVE via a follow-up PR after success.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tezca-rmf-catchup-20260716
+  labels:
+    app.kubernetes.io/name: tezca-rmf-catchup
+    app.kubernetes.io/part-of: tezca
+    app.kubernetes.io/component: dataops-oneshot
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tezca-rmf-catchup
+        app.kubernetes.io/part-of: tezca
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: ghcr-credentials
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: catchup
+          image: ghcr.io/madfam-org/tezca/api
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsUser: 1001
+            capabilities:
+              drop: ["ALL"]
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -x
+              echo "=== RMF: scrape 2026 (polite 1 req/s) + ingest ==="
+              python -m apps.scraper.federal.rmf_scraper --year 2026 --download \
+                && python manage.py ingest_rmf --catalog data/rmf/catalog.json \
+                || echo "RMF catch-up failed (non-fatal for the rest)"
+              echo "=== opportunistic ingests (no-op when catalog absent) ==="
+              python manage.py ingest_treaties --all || true
+              python manage.py ingest_noms || true
+              python manage.py ingest_state_catalogs --all || true
+              python manage.py ingest_conamer --all || true
+              echo "=== catch-up complete ==="
+          env:
+            - name: DJANGO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-secrets
+                  key: DJANGO_SECRET_KEY
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-secrets
+                  key: DB_USER
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-secrets
+                  key: DB_PASSWORD
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-secrets
+                  key: DB_HOST
+            - name: DEBUG
+              value: "False"
+            - name: DB_ENGINE
+              value: "django.db.backends.postgresql"
+            - name: DB_NAME
+              value: "tezca"
+            - name: DB_PORT
+              value: "5432"
+            - name: ES_HOST
+              value: "http://tezca-es:9200"
+            - name: STORAGE_BACKEND
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-r2-credentials
+                  key: STORAGE_BACKEND
+            - name: R2_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-r2-credentials
+                  key: R2_ACCESS_KEY_ID
+            - name: R2_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-r2-credentials
+                  key: R2_SECRET_ACCESS_KEY
+            - name: R2_ENDPOINT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-r2-credentials
+                  key: R2_ENDPOINT_URL
+            - name: R2_BUCKET_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-r2-credentials
+                  key: R2_BUCKET_NAME
+          resources:
+            requests:
+              cpu: 50m
+              memory: 384Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi


### PR DESCRIPTION
**Draft — merging this executes a production data operation** (scrape sat.gob.mx politely at 1 req/s + ingest into the Law table), per the side-effect doctrine it stays a explicit go-decision.

## Why
The RMF quarterly scrape ran 2026-07-08 on the April image; its pod-local catalog died with today's rollout, and the new `rmf-catalog-ingest-quarterly` Beat entry (day 9) missed its July window. Without this Job, the SAT fiscal feed — Karafiel's Wave-1 dependency, with `domain_filter: fiscal` webhook fanout — waits until **October 9**.

## What
One-shot k8s Job (`tezca-rmf-catchup-20260716`): RMF scrape (2026, `--download`) → `ingest_rmf`, then opportunistic `ingest_treaties/noms/state_catalogs/conamer` (each no-ops when its catalog is absent; all idempotent upserts). Worker-equivalent env (DB + R2), image pinned to the current tezca-api digest via the kustomization transform, `activeDeadlineSeconds: 3600`, `backoffLimit: 1`.

## Lifecycle
Argo applies once → runs to completion → lingers Completed (**no TTL** — deletion would trigger Argo recreate/re-run). Follow-up PR removes it after logs are reviewed.

## Alternative
Do nothing: treaties refill next Wed, NOMs tomorrow, states Aug 5 — only RMF truly needs this Job before October.

🤖 Generated with [Claude Code](https://claude.com/claude-code)