### PR TITLE
fix(api): writable /app/data in image + RMF catch-up retry (r2)

### DIFF
--- a/apps/indigo/Dockerfile
+++ b/apps/indigo/Dockerfile
@@ -88,8 +88,8 @@ COPY . .
 RUN python apps/manage.py collectstatic --noinput 2>/dev/null || true
 
 # Create directories for runtime data
-RUN mkdir -p /app/staticfiles /app/logs && \
-    chown -R django:django /app/staticfiles /app/logs
+RUN mkdir -p /app/staticfiles /app/logs /app/data && \
+    chown -R django:django /app/staticfiles /app/logs /app/data
 
 USER django
 

--- a/k8s/production/tezca-rmf-catchup-job.yaml
+++ b/k8s/production/tezca-rmf-catchup-job.yaml
@@ -13,7 +13,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: tezca-rmf-catchup-20260716
+  name: tezca-rmf-catchup-20260716-r2
   labels:
     app.kubernetes.io/name: tezca-rmf-catchup
     app.kubernetes.io/part-of: tezca
@@ -122,3 +122,13 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
+          # The image lacks a writable /app/data for uid 1001 (Dockerfile
+          # fix ships separately); scrape+ingest happen in one pod lifetime
+          # so ephemeral is fine here.
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+      volumes:
+        - name: data
+          emptyDir:
+            sizeLimit: 2Gi


### PR DESCRIPTION
The #169 catch-up Job ran and exposed a real latent regression: the image's Dockerfile creates `/app/staticfiles` and `/app/logs` for the non-root user but **not `/app/data`** — every scraper writing relative `data/` paths dies with `PermissionError: mkdir 'data' denied` (uid 1001). **Tomorrow's scheduled NOM scrape (worker, 03:00 UTC) and every scraper after it would have crashed.** The Job's other ingests no-op'd cleanly as designed (catalogs absent post-rollout).

- **Dockerfile**: `/app/data` added to the mkdir+chown — root cause; auto-builds + deploys on merge via the fresh-package pipeline
- **Job r2**: replaces the completed Job, with an emptyDir at `/app/data` so the RMF scrape+ingest runs correctly on the *current* image immediately

Merging = executing the retry (already authorized: 'Merge, Monitor').

🤖 Generated with [Claude Code](https://claude.com/claude-code)