### PR TITLE
fix(deploy): pass NPM token as BuildKit secret, not build-arg (web+admin)

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -87,7 +87,8 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=https://api.tezca.mx/api/v1
             NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_JANUA_ADMIN_PUBLISHABLE_KEY }}
-            NPM_MADFAM_TOKEN=${{ secrets.NPM_MADFAM_TOKEN }}
+          secrets: |
+            npm_token=${{ secrets.NPM_MADFAM_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -88,7 +88,8 @@ jobs:
             NEXT_PUBLIC_API_URL=https://api.tezca.mx/api/v1
             NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_JANUA_PUBLISHABLE_KEY }}
             NEXT_PUBLIC_MONETIZATION_ENABLED=true
-            NPM_MADFAM_TOKEN=${{ secrets.NPM_MADFAM_TOKEN }}
+          secrets: |
+            npm_token=${{ secrets.NPM_MADFAM_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false


### PR DESCRIPTION
The web/admin deploys (dispatched after #175) failed at `npm ci` with **E401 despite a valid `NPM_MADFAM_TOKEN`**. The token was passed as a `--build-arg`, but `apps/{web,admin}/Dockerfile` read it via `RUN --mount=type=secret,id=npm_token,env=NPM_MADFAM_TOKEN`. A build-arg populates ARG/ENV, never a BuildKit secret mount → `${NPM_MADFAM_TOKEN}` in `.npmrc` expanded empty → 401.

Fix: both workflows now use build-push-action's `secrets: npm_token=...` channel, matching the Dockerfiles. (API deploy unaffected — no `npm ci` in its image.)

After merge I'll re-dispatch both — this is the true last blocker for the web/admin April→current jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)