### PR TITLE
fix(docker): npm ci --legacy-peer-deps in web/admin images (match CI)

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -19,12 +19,12 @@ COPY packages/lib/package.json packages/lib/package.json
 # persists in image layers.
 # Build with: DOCKER_BUILDKIT=1 docker build --secret id=npm_token,env=NPM_MADFAM_TOKEN ...
 RUN --mount=type=secret,id=npm_token,env=NPM_MADFAM_TOKEN \
-    npm ci --workspace=apps/admin --workspace=packages/ui --workspace=packages/lib \
+    npm ci --legacy-peer-deps --workspace=apps/admin --workspace=packages/ui --workspace=packages/lib \
     && mkdir -p apps/admin/node_modules packages/ui/node_modules packages/lib/node_modules
 
 # Explicitly install musl-compatible native bindings for Alpine
 # npm ci --workspace=... skips platform-specific optional deps (npm/cli#4828)
-RUN npm install --no-save \
+RUN npm install --no-save --legacy-peer-deps \
     lightningcss-linux-x64-musl \
     @tailwindcss/oxide-linux-x64-musl \
     @rollup/rollup-linux-x64-musl \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,12 +19,12 @@ COPY packages/lib/package.json packages/lib/package.json
 # Token sourced from BuildKit secret so it never persists in image layers.
 # Build with: DOCKER_BUILDKIT=1 docker build --secret id=npm_token,env=NPM_MADFAM_TOKEN ...
 RUN --mount=type=secret,id=npm_token,env=NPM_MADFAM_TOKEN \
-    npm ci --workspace=apps/web --workspace=packages/ui --workspace=packages/lib \
+    npm ci --legacy-peer-deps --workspace=apps/web --workspace=packages/ui --workspace=packages/lib \
     && mkdir -p apps/web/node_modules packages/ui/node_modules packages/lib/node_modules
 
 # Explicitly install musl-compatible native bindings for Alpine
 # npm ci --workspace=... skips platform-specific optional deps (npm/cli#4828)
-RUN npm install --no-save \
+RUN npm install --no-save --legacy-peer-deps \
     lightningcss-linux-x64-musl \
     @tailwindcss/oxide-linux-x64-musl \
     @rollup/rollup-linux-x64-musl \


### PR DESCRIPTION
Peeling the onion on the web/admin deploys: #175 fixed the GHCR package, #176 fixed the BuildKit secret (E401 gone — the token authenticates), and this fixes the next layer: **ERESOLVE** react-19 peer conflicts. CI has always installed with `npm ci --legacy-peer-deps`; the Dockerfiles resolved strictly. Aligned so the image build sees the same tree the tests validate.

Note: these PRs touch `apps/{web,admin}` so their own frontend CI now actually runs — with the fresh token — making this PR itself the first full frontend CI validation since the token expired.

I'll re-dispatch both deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)