### PR TITLE
fix(web): SSR-safe localStorage — Node 25 ships a stub that passes typeof guards

### DIFF
--- a/apps/web/components/ComparisonHint.tsx
+++ b/apps/web/components/ComparisonHint.tsx
@@ -14,7 +14,15 @@ const labels = {
 
 function useIsDismissed() {
     const subscribe = useCallback(() => () => {}, []);
-    const getSnapshot = useCallback(() => typeof window !== 'undefined' && localStorage.getItem(STORAGE_KEY) === '1', []);
+    const getSnapshot = useCallback(() => {
+        if (typeof window === 'undefined') return true;
+        if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return true;
+        try {
+            return localStorage.getItem(STORAGE_KEY) === '1';
+        } catch {
+            return true;
+        }
+    }, []);
     const getServerSnapshot = useCallback(() => true, []); // hide on SSR
     return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
@@ -26,7 +34,13 @@ export function ComparisonHint() {
 
     const dismiss = () => {
         setHidden(true);
-        localStorage.setItem(STORAGE_KEY, '1');
+        try {
+            if (typeof localStorage !== 'undefined' && typeof localStorage.setItem === 'function') {
+                localStorage.setItem(STORAGE_KEY, '1');
+            }
+        } catch {
+            // localStorage unavailable
+        }
     };
 
     const show = !dismissed && !hidden;

--- a/apps/web/components/DisclaimerBanner.tsx
+++ b/apps/web/components/DisclaimerBanner.tsx
@@ -30,6 +30,9 @@ const content = {
 
 function getSnapshot(): boolean {
   try {
+    if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
+      return false;
+    }
     return !localStorage.getItem(STORAGE_KEY);
   } catch {
     return false;
@@ -55,7 +58,9 @@ export function DisclaimerBanner() {
   const dismiss = useCallback(() => {
     setDismissed(true);
     try {
-      localStorage.setItem(STORAGE_KEY, '1');
+      if (typeof localStorage !== 'undefined' && typeof localStorage.setItem === 'function') {
+        localStorage.setItem(STORAGE_KEY, '1');
+      }
     } catch {
       // localStorage unavailable
     }

--- a/apps/web/components/ErrorBoundary.tsx
+++ b/apps/web/components/ErrorBoundary.tsx
@@ -14,6 +14,7 @@ interface State {
 
 function getPreferredLang(): 'es' | 'en' | 'nah' {
   if (typeof window === 'undefined') return 'es';
+  if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return 'es';
   try {
     const stored = localStorage.getItem('preferred-lang');
     if (stored === 'en' || stored === 'nah') return stored;

--- a/apps/web/components/FontSizeControl.tsx
+++ b/apps/web/components/FontSizeControl.tsx
@@ -14,8 +14,13 @@ export type { FontSize };
 
 function readStoredSize(): FontSize {
     if (typeof window === 'undefined') return 'text-base';
-    const stored = localStorage.getItem(STORAGE_KEY) as FontSize | null;
-    return stored && SIZES.includes(stored) ? stored : 'text-base';
+    if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return 'text-base';
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY) as FontSize | null;
+        return stored && SIZES.includes(stored) ? stored : 'text-base';
+    } catch {
+        return 'text-base';
+    }
 }
 
 export function FontSizeControl({ onChange }: FontSizeControlProps) {
@@ -24,7 +29,13 @@ export function FontSizeControl({ onChange }: FontSizeControlProps) {
     const [, setTick] = useState(0);
 
     const handleChange = (newSize: FontSize) => {
-        localStorage.setItem(STORAGE_KEY, newSize);
+        try {
+            if (typeof localStorage !== 'undefined' && typeof localStorage.setItem === 'function') {
+                localStorage.setItem(STORAGE_KEY, newSize);
+            }
+        } catch {
+            // localStorage unavailable
+        }
         setTick((t) => t + 1);
         onChange(newSize);
     };

--- a/apps/web/components/RecentlyViewed.tsx
+++ b/apps/web/components/RecentlyViewed.tsx
@@ -37,6 +37,7 @@ const content = {
 /** Call on law detail mount to record a visit */
 export function recordLawView(entry: Omit<RecentLawEntry, 'viewedAt'>) {
     if (typeof window === 'undefined') return;
+    if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return;
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
         let items: RecentLawEntry[] = raw ? JSON.parse(raw) : [];
@@ -51,6 +52,9 @@ export function recordLawView(entry: Omit<RecentLawEntry, 'viewedAt'>) {
 
 function getSnapshot(): string {
     try {
+        if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
+            return '[]';
+        }
         return localStorage.getItem(STORAGE_KEY) || '[]';
     } catch {
         return '[]';

--- a/apps/web/components/providers/AuthContext.tsx
+++ b/apps/web/components/providers/AuthContext.tsx
@@ -173,8 +173,12 @@ function getToken(): string | null {
         const match = document.cookie.match(/(?:^|;\s*)janua_token=([^;]*)/);
         if (match) return decodeURIComponent(match[1]);
     }
-    if (typeof localStorage !== 'undefined') {
-        return localStorage.getItem('janua_token');
+    if (typeof localStorage !== 'undefined' && typeof localStorage.getItem === 'function') {
+        try {
+            return localStorage.getItem('janua_token');
+        } catch {
+            return null;
+        }
     }
     return null;
 }

--- a/apps/web/components/providers/BookmarksContext.tsx
+++ b/apps/web/components/providers/BookmarksContext.tsx
@@ -31,6 +31,7 @@ function emitChange() {
 
 function getSnapshot(): Bookmark[] {
     if (typeof window === 'undefined') return EMPTY;
+    if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return EMPTY;
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (raw !== cachedRaw) {
@@ -59,7 +60,13 @@ export function BookmarksProvider({ children }: { children: React.ReactNode }) {
 
     const persist = useCallback((next: Bookmark[]) => {
         const raw = JSON.stringify(next);
-        localStorage.setItem(STORAGE_KEY, raw);
+        try {
+            if (typeof localStorage !== 'undefined' && typeof localStorage.setItem === 'function') {
+                localStorage.setItem(STORAGE_KEY, raw);
+            }
+        } catch {
+            // localStorage unavailable
+        }
         // Update cache immediately so getSnapshot returns stable reference
         cachedRaw = raw;
         cachedBookmarks = next;

--- a/apps/web/components/providers/ComparisonContext.tsx
+++ b/apps/web/components/providers/ComparisonContext.tsx
@@ -13,6 +13,7 @@ const ComparisonContext = createContext<ComparisonContextType | undefined>(undef
 
 function getInitialLaws(): string[] {
     if (typeof window === 'undefined') return [];
+    if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return [];
     try {
         const stored = localStorage.getItem('comparison_selected_laws');
         return stored ? JSON.parse(stored) : [];
@@ -31,7 +32,13 @@ export function ComparisonProvider({ children }: { children: React.ReactNode }) 
             isInitialMount.current = false;
             return;
         }
-        localStorage.setItem('comparison_selected_laws', JSON.stringify(selectedLaws));
+        try {
+            if (typeof localStorage !== 'undefined' && typeof localStorage.setItem === 'function') {
+                localStorage.setItem('comparison_selected_laws', JSON.stringify(selectedLaws));
+            }
+        } catch {
+            // localStorage unavailable
+        }
     }, [selectedLaws]);
 
     const toggleLaw = (lawId: string) => {

--- a/apps/web/components/providers/LanguageContext.tsx
+++ b/apps/web/components/providers/LanguageContext.tsx
@@ -22,6 +22,9 @@ const STORAGE_KEY = 'preferred-lang';
 
 function getSnapshot(): Lang {
   try {
+    if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
+      return 'es';
+    }
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === 'en' || stored === 'nah') return stored;
     return 'es';
@@ -48,7 +51,9 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
     trackEvent('language.switched', { from: lang, to: newLang });
     setOverride(newLang);
     try {
-      localStorage.setItem(STORAGE_KEY, newLang);
+      if (typeof localStorage !== 'undefined' && typeof localStorage.setItem === 'function') {
+        localStorage.setItem(STORAGE_KEY, newLang);
+      }
     } catch {
       // localStorage unavailable
     }

--- a/apps/web/lib/auth-token.ts
+++ b/apps/web/lib/auth-token.ts
@@ -6,8 +6,12 @@ export function getAuthToken(): string | null {
         const match = document.cookie.match(/(?:^|;\s*)janua_token=([^;]*)/);
         if (match) return decodeURIComponent(match[1]);
     }
-    if (typeof localStorage !== 'undefined') {
-        return localStorage.getItem('janua_token');
+    if (typeof localStorage !== 'undefined' && typeof localStorage.getItem === 'function') {
+        try {
+            return localStorage.getItem('janua_token');
+        } catch {
+            return null;
+        }
     }
     return null;
 }


### PR DESCRIPTION
**The final E2E-blocking defect** (task-19 diagnosis, full log-archive analysis): the E2E web-image build died prerendering `/_not-found` with `TypeError: localStorage.getItem is not a function`.

**Root cause (reproduced empirically in `node:25-alpine`):** Node 25 ships an experimental global `localStorage` that EXISTS as an object but whose methods are `undefined` without `--localstorage-file`. Every `typeof window`/`typeof localStorage` guard passes — then the call crashes. Node 20/22 (local dev, CI unit tests) define no global at all, which is why this never reproduced outside the container.

**Culprit for `/_not-found`:** `LanguageContext.getSnapshot()` (wraps the whole app; `useLang()` is called directly in `not-found.tsx`) — render-time `localStorage.getItem` with no method guard. `AuthContext.getToken()` (render-time `useMemo`) was the second app-wide hazard. **All 10 unsafe sites fixed** with method-level guards + try/catch.

**Verified:** `next build` inside a fresh `node:25-alpine` container → **exit 0**, `/_not-found` prerenders Static; local build exit 0; vitest 930/930; lint 0 errors.

Also required for the web *deploy* (same Dockerfile, same Node 25) — the deploy would have crashed here after clearing the npm layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)