### PR TITLE
ci(e2e): raise infra build timeout 10→25 min (layer 13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,10 @@ jobs:
       env:
         POSTGRES_PASSWORD: test_pw
       run: docker compose -f docker-compose.e2e.yml up -d --build
-      timeout-minutes: 10
+      # Cacheless from-scratch build of the poetry API image + Next.js web
+      # image on a 2-core runner takes >10 min; the old budget predates the
+      # E2E stack ever reaching the build (it failed earlier for months).
+      timeout-minutes: 25
 
     - name: Wait for services
       run: |


### PR DESCRIPTION
The E2E stack now builds **successfully** end-to-end — the web builder's final `server.js` sanity check passes — but hits the Start step's `timeout-minutes: 10` (exit 124). Cacheless API (poetry) + web (Next) image builds on a 2-core runner need more than 10 minutes; the budget was never calibrated because the step spent months failing before ever reaching the build.

This PR's own E2E run is the first with a real chance to go fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)