### PR TITLE
ci(e2e): logs-on-failure + 300s service wait (layer 14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,9 +279,18 @@ jobs:
       timeout-minutes: 25
 
     - name: Wait for services
+      # Cold API startup = full migrate + ES index seed before runserver;
+      # 180s raced it. 300s observed-safe; the log dump below makes any
+      # future failure self-documenting instead of a guessing game.
       run: |
-        timeout 180 bash -c 'until curl -fs http://localhost:8000/api/v1/stats/; do sleep 3; done'
+        timeout 300 bash -c 'until curl -fs http://localhost:8000/api/v1/stats/; do sleep 3; done'
         timeout 60 bash -c 'until curl -fs http://localhost:3000; do sleep 2; done'
+
+    - name: Dump compose logs on failure
+      if: failure()
+      env:
+        POSTGRES_PASSWORD: test_pw
+      run: docker compose -f docker-compose.e2e.yml logs --tail=200
 
     - name: Run Playwright tests
       run: npx playwright test --project=chromium


### PR DESCRIPTION
Builds now complete in ~3.5 min (caching); the gate fails at **Wait for services** — API container doesn't serve `/api/v1/stats/` in 180s (cold `migrate` + `index_laws` seed before `runserver`), and the workflow discarded the container logs. This makes the next failure self-documenting (`docker compose logs --tail=200` on failure) and gives startup a realistic 300s budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)