### PR TITLE
fix(e2e): correct the index_laws seed command (layer 15 — the real root cause)

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -83,7 +83,7 @@ services:
       dockerfile: apps/indigo/Dockerfile
     command: >
       sh -c "python manage.py migrate --noinput &&
-             python manage.py index_laws --tier federal --limit 10 &&
+             python manage.py index_laws --all --tier federal --limit 10 --create-indices &&
              python manage.py runserver 0.0.0.0:8000"
     environment:
       - DEBUG=True


### PR DESCRIPTION
The logs-on-failure step from #181 paid off immediately. The API container's seed ran `index_laws --tier federal --limit 10` — but `index_laws` requires the mutually-exclusive `--all`/`--law-id` group, so:
```
manage.py index_laws: error: one of the arguments --all --law-id is required
```
Non-zero exit → `&&` short-circuits → `runserver` never launches → `/api/v1/stats/` never responds → timeout. **The E2E gate's API has literally never started** — this seed command predates the current `index_laws` CLI.

Fix: `--all` + `--create-indices` (fresh ES). Empty-corpus index exits 0 (ES is `depends_on: service_healthy`), so the chain reaches `runserver`.

This should be the last layer — with the API actually serving, the Playwright suite finally runs against a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)