### PR TITLE
fix(e2e): raise ES memory to stop startup OOM (layer 17)

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -67,9 +67,12 @@ services:
       resources:
         limits:
           cpus: '1.0'
-          memory: 768M
+          # 384m heap + ES 8.x off-heap (Lucene mmap, direct buffers, thread
+          # stacks) needs ~1.5x total; 768M left no margin and OOM-killed ES
+          # at startup (exit 137) under GH-runner memory pressure.
+          memory: 1200M
         reservations:
-          memory: 512M
+          memory: 640M
     healthcheck:
       test: ["CMD-SHELL", "curl -fs http://localhost:9200/_cluster/health || exit 1"]
       interval: 10s


### PR DESCRIPTION
#185's E2E run surfaced a new infra failure (the spec fixes themselves are correct — 79/79 locally): `elasticsearch died while starting up, exit code 137` = **OOM-killed**. ES ran `-Xmx384m` heap in a 768M container; ES 8.x needs ~1.5× heap total for off-heap memory, so it OOMs at startup under GH-runner pressure. Since `api` waits on ES `service_healthy`, ES dying kills the gate before specs run.

ES container limit 768M → 1200M (reservations 640M). Total stack limits 2.8GB, well within a runner's ~7GB.

This should be the layer that finally lets #185's spec fixes prove out green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)