### PR TITLE
fix(scraper): reach madfam-crawler via in-cluster FQDN + crawler egress netpol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,14 @@ NEXT_PUBLIC_DHANAM_API_URL=https://api.dhan.am
 TRIAL_DURATION_NO_CC_DAYS=3
 TRIAL_DURATION_WITH_CC_DAYS=21
 
+# ── Madfam Crawler (scraping-as-a-service) ────────────────────────────
+# Crawl endpoint of the shared madfam-crawler service. MadfamBridge
+# (apps/scraper/client/madfam_bridge.py) delegates hostile detail-page
+# extraction here. Defaults to the in-cluster FQDN
+# (service "crawler-api", namespace "madfam-crawler"); override for
+# local/dev setups.
+# MADFAM_CRAWLER_URL=http://crawler-api.madfam-crawler.svc.cluster.local:8000/v1/crawl
+
 # ── CRM (Phynd-CRM) ───────────────────────────────────────────────────
 # Webhook receiver for interest.created / newsletter.subscribed events.
 # When unset, crm_sync.py no-ops cleanly.

--- a/apps/scraper/client/madfam_bridge.py
+++ b/apps/scraper/client/madfam_bridge.py
@@ -7,6 +7,7 @@ heavy headless browser DOM processing to the central `madfam-crawler` architectu
 
 import asyncio
 import logging
+import os
 import time
 from typing import Any, Dict, Optional
 
@@ -14,10 +15,19 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+# The shared crawler runs as service "crawler-api" in the "madfam-crawler"
+# namespace. A bare "madfam-crawler:8000" short name never resolves from the
+# tezca namespace (cross-namespace lookups need the full service FQDN), so
+# the default is the in-cluster FQDN and stays overridable via
+# MADFAM_CRAWLER_URL for local/dev setups.
+DEFAULT_CRAWLER_URL = (
+    "http://crawler-api.madfam-crawler.svc.cluster.local:8000/v1/crawl"
+)
+
 
 class MadfamBridge:
-    def __init__(self, endpoint: str = "http://madfam-crawler:8000/v1/crawl"):
-        self.endpoint = endpoint
+    def __init__(self, endpoint: Optional[str] = None):
+        self.endpoint = endpoint or os.getenv("MADFAM_CRAWLER_URL", DEFAULT_CRAWLER_URL)
         self.poll_interval = 5.0  # seconds
 
     def extract_sync(

--- a/k8s/production/network-policies.yaml
+++ b/k8s/production/network-policies.yaml
@@ -135,3 +135,32 @@ spec:
     - ports:
         - protocol: TCP
           port: 443
+---
+# Allow egress to the shared madfam-crawler namespace (crawler-api :8000).
+# MadfamBridge (apps/scraper/client/madfam_bridge.py) delegates hostile
+# detail-page extraction to the central crawler at
+# http://crawler-api.madfam-crawler.svc.cluster.local:8000. The egress
+# isolation triggered by allow-intra-namespace otherwise rejects TCP 8000
+# even when the FQDN resolves.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-crawler-egress
+  namespace: tezca
+  labels:
+    app.kubernetes.io/part-of: tezca
+    app.kubernetes.io/component: networkpolicy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: tezca
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: madfam-crawler
+      ports:
+        - protocol: TCP
+          port: 8000

--- a/k8s/production/tezca-worker-deployment.yaml
+++ b/k8s/production/tezca-worker-deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: "redis://tezca-redis:6379/0"
             - name: ES_HOST
               value: "http://tezca-es:9200"
+            - name: MADFAM_CRAWLER_URL
+              value: "http://crawler-api.madfam-crawler.svc.cluster.local:8000/v1/crawl"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Root cause (two independent blockers)

The shared crawler service is reachable only at `http://crawler-api.madfam-crawler.svc.cluster.local:8000` (service `crawler-api` in namespace `madfam-crawler`, healthy 2/2). Tezca's `MadfamBridge` instead called `http://madfam-crawler:8000` — and both network layers were broken:

1. **DNS**: a bare `madfam-crawler:8000` short name never resolves cross-namespace → `ENOTFOUND`.
2. **NetworkPolicy**: the tezca namespace's egress allowlist (`allow-intra-namespace` isolation + DNS/data/443 allows) has no rule for TCP 8000 to another namespace, so even the correct FQDN is rejected → `ECONNREFUSED` (k3s reject).

**Baseline evidence** (read-only `kubectl exec` into the live `tezca-worker` pod, 2026-07-19):

```
http://crawler-api.madfam-crawler.svc.cluster.local:8000/health -> URLError [Errno 111] Connection refused   (netpol layer)
http://madfam-crawler:8000/health                               -> URLError [Errno -5] No address associated with hostname   (DNS layer)
```

The `madfam-crawler` namespace has no NetworkPolicies, so no ingress-side change is needed. Mirrors the already-merged pattern in madfam-org/avala#225.

## What changed

- `apps/scraper/client/madfam_bridge.py` — `MadfamBridge.__init__` default endpoint is now `os.getenv("MADFAM_CRAWLER_URL", "http://crawler-api.madfam-crawler.svc.cluster.local:8000/v1/crawl")`, resolved at instantiation time; explicit `endpoint` arg still wins. The only instantiation in the repo (`scjn_playwright.py:95`, `MadfamBridge()`) uses the default — no caller passed the dead endpoint explicitly. Repo-wide grep confirms no other `madfam-crawler:8000` occurrences remain (docs mention the service by name only, no URLs).
- `k8s/production/network-policies.yaml` — new `allow-crawler-egress` NetworkPolicy: TCP 8000 to `namespaceSelector kubernetes.io/metadata.name=madfam-crawler`, same `podSelector`/label conventions as the existing allowlist policies.
- `k8s/production/tezca-worker-deployment.yaml` — `MADFAM_CRAWLER_URL` set explicitly (the Celery worker is the workload that executes scraper tasks; beat only schedules).
- `.env.example` — documents `MADFAM_CRAWLER_URL`.

## Corpus-freeze analysis (report-only, no ingest logic touched)

Tezca's corpus has been frozen since 2026-01-19. Trace of whether this dead bridge contributes:

- **CONAMER: not a contributor.** Neither `apps/scraper/federal/conamer_scraper.py` (requests-based) nor `conamer_playwright.py` (in-process Playwright) imports or calls `MadfamBridge`. The CONAMER freeze has a different cause.
- **SCJN: plausible partial contributor for 2026-04-03 → 2026-07-15, but cannot explain the freeze's onset.** `MadfamBridge` was introduced 2026-04-03 (`02aedcb6`, "establish MadfamBridge and decommission internal SCJN regression scrape loop") — 2.5 months *after* the freeze began, so it cannot have caused the 2026-01-19 onset. During 2026-04-03 → 2026-07-15 it was the *only* detail-extraction path in `scjn_playwright.py` (`_enrich_records` → `_fetch_detail_page` → `extract_sync`). Bridge failures are swallowed (returns `None` → `{}`), so scrapes "succeeded" while every record whose listing row lacked `texto`/`rubro` stayed empty — and `ingest_judicial._is_degenerate()` then silently drops exactly those records. Net effect: silent SCJN corpus starvation during that window. Since 2026-07-15 (#154, `sjf_api.py`), the SJF JSON API is the primary detail path and the bridge is only a fallback, shrinking (but not eliminating) its impact — the fallback still matters wherever the SJF API is unreachable.

## Verification

- `python -m py_compile apps/scraper/client/madfam_bridge.py` — OK
- `poetry run black --check` + `poetry run isort --check-only` on the touched file — clean
- `poetry run pytest tests/scraper/test_scjn_playwright.py tests/scraper/test_scjn_playwright_full.py` — 40 passed, 1 skipped
- Endpoint resolution smoke test: default FQDN / `MADFAM_CRAWLER_URL` override / explicit arg all resolve correctly
- `kubectl kustomize k8s/production` builds cleanly (26 objects incl. the new policy); YAML parse validated
- Baseline probes above prove both failure layers from the live worker pod

GitOps only — nothing applied to the cluster from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)