### PR TITLE
feat(scraper): send X-Api-Key crawler auth header from MADFAM_CRAWLER_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,13 @@ TRIAL_DURATION_WITH_CC_DAYS=21
 # (service "crawler-api", namespace "madfam-crawler"); override for
 # local/dev setups.
 # MADFAM_CRAWLER_URL=http://crawler-api.madfam-crawler.svc.cluster.local:8000/v1/crawl
+# API key for the crawler's ApiKeyMiddleware. When set, MadfamBridge sends
+# it as "X-Api-Key" on every crawler request (dispatch POST + status-poll
+# GETs); when unset, the header is omitted (local/dev crawlers without
+# auth). In production this is wired from the tezca-secrets key
+# MADFAM_CRAWLER_TOKEN (optional: true), minted by the operator and
+# mirrored into the crawler's API_KEYS.
+# MADFAM_CRAWLER_TOKEN=placeholder-crawler-token
 
 # ── CRM (Phynd-CRM) ───────────────────────────────────────────────────
 # Webhook receiver for interest.created / newsletter.subscribed events.

--- a/apps/scraper/client/madfam_bridge.py
+++ b/apps/scraper/client/madfam_bridge.py
@@ -26,9 +26,21 @@ DEFAULT_CRAWLER_URL = (
 
 
 class MadfamBridge:
-    def __init__(self, endpoint: Optional[str] = None):
+    def __init__(self, endpoint: Optional[str] = None, api_key: Optional[str] = None):
         self.endpoint = endpoint or os.getenv("MADFAM_CRAWLER_URL", DEFAULT_CRAWLER_URL)
+        # The crawler's ApiKeyMiddleware expects "X-Api-Key: <token>" matching
+        # one of its comma-separated API_KEYS. Consumers configure the token
+        # via MADFAM_CRAWLER_TOKEN; when unset/empty (local dev crawlers
+        # without auth) the header is omitted entirely.
+        self.api_key = (
+            api_key if api_key is not None else os.getenv("MADFAM_CRAWLER_TOKEN", "")
+        )
         self.poll_interval = 5.0  # seconds
+
+    @property
+    def _auth_headers(self) -> Dict[str, str]:
+        """Headers sent on every crawler request (dispatch POST + status GETs)."""
+        return {"X-Api-Key": self.api_key} if self.api_key else {}
 
     def extract_sync(
         self,
@@ -45,7 +57,7 @@ class MadfamBridge:
             "source_app": "tezca",
         }
 
-        with httpx.Client(timeout=10.0) as client:
+        with httpx.Client(timeout=10.0, headers=self._auth_headers) as client:
             try:
                 logger.info(f"[MadfamBridge] Enqueueing scrape for {url}")
                 response = client.post(self.endpoint, json=payload)
@@ -93,7 +105,9 @@ class MadfamBridge:
             "source_app": "tezca",
         }
 
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(
+            timeout=10.0, headers=self._auth_headers
+        ) as client:
             try:
                 # 1. Dispatch
                 logger.info(f"[MadfamBridge] Enqueueing scrape for {url}")

--- a/k8s/production/tezca-worker-deployment.yaml
+++ b/k8s/production/tezca-worker-deployment.yaml
@@ -77,6 +77,16 @@ spec:
               value: "http://tezca-es:9200"
             - name: MADFAM_CRAWLER_URL
               value: "http://crawler-api.madfam-crawler.svc.cluster.local:8000/v1/crawl"
+            # API key for the crawler's ApiKeyMiddleware (sent as X-Api-Key).
+            # optional: true keeps the pod booting until the operator adds the
+            # MADFAM_CRAWLER_TOKEN key to tezca-secrets; without it the bridge
+            # omits the header and the crawler answers 401.
+            - name: MADFAM_CRAWLER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: tezca-secrets
+                  key: MADFAM_CRAWLER_TOKEN
+                  optional: true
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Follow-up to #187. The shared crawler (`crawler-api.madfam-crawler.svc:8000`) is now reachable from the tezca namespace, but its `ApiKeyMiddleware` rejects requests with **401** unless they carry `X-Api-Key: <token>` matching one of its comma-separated `API_KEYS` (per the documented consumer pattern in madfam-crawler `docs/RONDELIO_ONBOARDING.md`).

- **`apps/scraper/client/madfam_bridge.py`** — `MadfamBridge.__init__` now reads `MADFAM_CRAWLER_TOKEN` (an explicit `api_key` arg takes precedence). The token is sent as `X-Api-Key` on the enqueue POST and every status-poll GET in both `extract_sync` and the async `extract` (set as client-level headers on the `httpx.Client` / `httpx.AsyncClient`, so every request through them carries it). When the env is unset/empty (dev crawlers without auth) the header is omitted entirely.
- **`k8s/production/tezca-worker-deployment.yaml`** — wires `MADFAM_CRAWLER_TOKEN` via `valueFrom.secretKeyRef` against the existing `tezca-secrets` secret with `optional: true`, so pods keep booting until the operator adds the key.
- **`.env.example`** — documents the new variable.

**Operator follow-up (not in this PR, no secrets touched here):** mint a token, add it as key `MADFAM_CRAWLER_TOKEN` in `tezca-secrets` (tezca namespace), and append the same value to the crawler's `API_KEYS` (`madfam-crawler-secrets`, madfam-crawler namespace).

## Verification

- `python3 -m py_compile apps/scraper/client/madfam_bridge.py` — OK
- `poetry run black --check apps/scraper/client/madfam_bridge.py` — clean
- `poetry run isort --check-only apps/scraper/client/madfam_bridge.py` — clean
- `poetry run pytest tests/scraper/test_scjn_playwright.py tests/scraper/test_scjn_playwright_full.py` — **40 passed, 1 skipped** (same suite that passed in #187)
- Manifest YAML parses; `MADFAM_CRAWLER_TOKEN` env renders with `secretKeyRef {name: tezca-secrets, key: MADFAM_CRAWLER_TOKEN, optional: true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)