### PR TITLE
docs: sanitized statement of this repo's role in the monetization engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,24 @@ This project uses a monorepo architecture managed by NPM Workspaces.
   - **Public Portal**: Citizen-facing search and traversal of laws
   - **Admin Console**: Operator dashboard for monitoring ingestion jobs
 
+## Role in the MADFAM monetization engine
+
+Tezca is a revenue-carrying product in MADFAM's compliance line, not an internal tool. It is aimed at the people
+whose work depends on knowing what Mexican law currently says — compliance officers, accountants, legal and
+regulatory teams — with paid tiers layered over the public corpus and the machine-readable API as the principal
+commercial surface.
+
+Its place in the wider MADFAM pipeline is simply that of a product to be sold. Demand discovery, pricing,
+checkout, invoicing, and entitlement are each owned by other platforms; none of that path lives in this
+repository, and nothing here should grow a dependency on it.
+
+> **Boundary note.** This is a deliberately sanitized statement of role. The canonical end-to-end description of
+> the monetization pipeline is private and lives in the `internal-devops` repository at
+> `docs/monetization-engine.md`. Catalog prices, payment and entitlement wiring, credential names, deployment
+> topology, and tax/invoicing configuration belong there and must not be added to this repository.
+
+_Last Updated: 2026-07-26_
+
 ## Documentation
 
 - [Setup Guide](docs/guides/SETUP.md) - Installation and configuration

--- a/README.md
+++ b/README.md
@@ -138,16 +138,18 @@ This project uses a monorepo architecture managed by NPM Workspaces.
 
 ## Role in the MADFAM monetization engine
 
-Tezca is a revenue-carrying product in MADFAM's compliance line, not an internal tool. It is aimed at the people
-whose work depends on knowing what Mexican law currently says — compliance officers, accountants, legal and
-regulatory teams — with paid tiers layered over the public corpus and the machine-readable API as the principal
-commercial surface.
+Tezca is intended as a revenue-carrying product in MADFAM's compliance line, not an internal tool. It is aimed at
+the people whose work depends on knowing what Mexican law currently says — compliance officers, accountants, legal
+and regulatory teams — with the machine-readable API over the legal corpus as the principal commercial surface.
+Tezca is also an upstream data dependency for other MADFAM compliance products, which consume its feeds rather
+than re-deriving them.
 
 Its place in the wider MADFAM pipeline is simply that of a product to be sold. Demand discovery, pricing,
 checkout, invoicing, and entitlement are each owned by other platforms; none of that path lives in this
 repository, and nothing here should grow a dependency on it.
 
-> **Boundary note.** This is a deliberately sanitized statement of role. The canonical end-to-end description of
+> **Boundary note.** This is a deliberately sanitized statement of Tezca's *designed* role. It is not a statement
+> about the live state of any deployment, nor about current commercial availability. The canonical end-to-end description of
 > the monetization pipeline is private and lives in the `internal-devops` repository at
 > `docs/monetization-engine.md`. Catalog prices, payment and entitlement wiring, credential names, deployment
 > topology, and tax/invoicing configuration belong there and must not be added to this repository.


### PR DESCRIPTION
## What

Adds a short, sanitized statement of this repository role in the MADFAM monetization engine, so a contributor can understand why the repo matters commercially without needing private context.

## Why

The repo is public. Contributors could see what the code does but not what it is *for* commercially. This closes that gap at the role level only.

## Boundary

Deliberately withheld: deployment/cluster topology, credential and secret names, route and event names, fiscal/tax configuration, catalog prices, per-service operational state, and incident detail. The canonical end-to-end map is private and is referenced by path only (`internal-devops` at `docs/monetization-engine.md`), not reproduced.

Documentation only — no code, config, or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)