### PR TITLE
fix(netpol): allow karafiel-api ingress to tezca-api on 8000

### DIFF
--- a/k8s/production/network-policies.yaml
+++ b/k8s/production/network-policies.yaml
@@ -164,3 +164,44 @@ spec:
       ports:
         - protocol: TCP
           port: 8000
+---
+# Allow karafiel-api → tezca-api ingress on port 8000.
+#
+# Counterpart to karafiel's `karafiel-tezca-egress` policy
+# (karafiel/infra/k8s/production/network-policies.yaml). NetworkPolicy is
+# enforced on BOTH sides of a cross-namespace call: karafiel already permits
+# the egress, but tezca-api is ingress-isolated by `allow-cloudflared-ingress`
+# above (it selects every `part-of: tezca` pod with policyTypes: [Ingress]),
+# whose only allowed sources are the cloudflare-tunnel namespace and — via
+# `allow-intra-namespace` — pods inside tezca. A karafiel→tezca SYN therefore
+# still gets dropped here. See madfam-org/karafiel#39.
+#
+# Karafiel calls TEZCA_API_URL (http://tezca-api.tezca.svc.cluster.local:8000
+# /api/v1) for legal-oracle lookups during CFDI/payroll flows; on failure it
+# silently falls back to its hardcoded ISR/UMA tables, so the drop is invisible
+# in Karafiel's responses and only shows up as fiscal-data drift.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-karafiel-ingress
+  namespace: tezca
+  labels:
+    app.kubernetes.io/part-of: tezca
+    app.kubernetes.io/component: networkpolicy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tezca-api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: karafiel
+          podSelector:
+            matchLabels:
+              app: karafiel-api
+      ports:
+        - protocol: TCP
+          port: 8000


### PR DESCRIPTION
## What

Adds a single, purely-additive NetworkPolicy to the `tezca` namespace permitting ingress from `karafiel-api` to `tezca-api` on TCP 8000.

## Why

Triage of **madfam-org/karafiel#39** found that issue is half-fixed, and the remaining half lives in *this* repo:

| Layer | State |
|---|---|
| `TEZCA_API_URL` secret (prefix + port) | ✅ fixed by operator 2026-04-28 |
| karafiel-side egress (`karafiel-tezca-egress`) | ✅ present in `karafiel/infra/k8s/production/network-policies.yaml` |
| **tezca-side ingress** | ❌ **missing — this PR** |

NetworkPolicy is enforced on **both** ends of a cross-namespace call. `allow-cloudflared-ingress` in `k8s/production/network-policies.yaml` selects every `app.kubernetes.io/part-of: tezca` pod with `policyTypes: [Ingress]`, which isolates `tezca-api` for ingress. Its only permitted sources are:

- the `cloudflare-tunnel` namespace (`app: cloudflared`), and
- pods inside the `tezca` namespace, via `allow-intra-namespace` (`from: [{podSelector: {}}]` — same-namespace only).

`karafiel` matches neither, so the SYN is dropped regardless of karafiel's egress rule. Verified by reading the rendered manifests, not by inference: `grep karafiel k8s/production/network-policies.yaml` matched only a comment before this change.

## Why it is invisible today

`karafiel/apps/api/.../tezca_client.py` failures fall back to the hardcoded 2025 ISR/UMA tables (by design). So the drop never surfaces as an error in Karafiel's responses — only as fiscal data silently drifting as 2026 rates change.

## Selector grounding

- `podSelector: app.kubernetes.io/name: tezca-api` — matches `k8s/production/tezca-api-deployment.yaml` pod template labels.
- `from.podSelector: app: karafiel-api` — matches `karafiel/infra/k8s/production/api-deployment.yaml` (line 17), and mirrors the selector karafiel's own egress rule uses.
- Port 8000 — `tezca-api-service.yaml` `port`/`targetPort`.

## Risk

Additive only. NetworkPolicy rules are OR'd across policies, so this can permit traffic but cannot remove any currently-permitted path. No existing policy, deployment, or service is modified.

## Verification

```
$ kustomize build k8s/production | grep -c '^kind:'
26     # was 25
```

`network-policies.yaml` is already listed in `k8s/production/kustomization.yaml`, so no wiring change is needed.

## Post-merge check (operator)

```
kubectl exec -n karafiel deploy/karafiel-api -- \
  curl -s -m 5 -o /dev/null -w '%{http_code}\n' \
  http://tezca-api.tezca.svc.cluster.local:8000/api/v1/laws/
```
Expect `200`; currently this times out / connection-refused.

Refs madfam-org/karafiel#39