### PR TITLE
fix: make /health reachable by the in-cluster uptime probe

### DIFF
--- a/apps/indigo/settings.py
+++ b/apps/indigo/settings.py
@@ -210,6 +210,25 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # ── Production Security ───────────────────────────────────────────────
 if not DEBUG:
     SECURE_SSL_REDIRECT = True
+    # Exempt the health endpoint from the HTTP→HTTPS redirect.
+    #
+    # Public traffic is unaffected: Cloudflare terminates TLS and cloudflared
+    # forwards X-Forwarded-Proto: https, which SECURE_PROXY_SSL_HEADER below
+    # already honours, so https://api.tezca.mx/health keeps working exactly as
+    # it does now. But in-cluster callers speak plain HTTP to
+    # tezca-api.tezca.svc.cluster.local:8000 and set no such header, so
+    # SecurityMiddleware answers 301 → https://api.tezca.mx/health before the
+    # view ever runs. Verified 2026-08-06 inside a tezca-api pod.
+    #
+    # The kubelet probes never surfaced this because kubelet treats any 2xx OR
+    # 3xx as success — the pods report Ready on a redirect that proves only
+    # that SecurityMiddleware is loaded. The cloudflared uptime probe requires
+    # status 200, so the redirect is a hard failure for it.
+    #
+    # Anchored to the single root health route (apps/indigo/urls.py
+    # `path("health", ...)`, matched without the leading slash per Django's
+    # SECURE_REDIRECT_EXEMPT contract). Every other path still redirects.
+    SECURE_REDIRECT_EXEMPT = [r"^health$"]
     SECURE_HSTS_SECONDS = 31536000
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True

--- a/deployment/enclii/tezca-api.yaml
+++ b/deployment/enclii/tezca-api.yaml
@@ -28,8 +28,12 @@ env:
     secretRef: tezca-secrets/django-secret-key
   - name: DEBUG
     value: "False"
+  # Keep in sync with k8s/production/tezca-api-deployment.yaml — the
+  # cluster-internal Service DNS name must be allowed or in-cluster callers
+  # (the cloudflared uptime probe, karafiel's legal-oracle lookups) get 400
+  # DisallowedHost.
   - name: ALLOWED_HOSTS
-    value: "api.tezca.mx"
+    value: "api.tezca.mx,tezca-api.tezca.svc.cluster.local"
   - name: CORS_ALLOWED_ORIGINS
     value: "https://tezca.mx,https://www.tezca.mx,https://admin.tezca.mx"
   - name: DB_ENGINE

--- a/k8s/production/network-policies.yaml
+++ b/k8s/production/network-policies.yaml
@@ -24,6 +24,39 @@ spec:
           podSelector:
             matchLabels:
               app: cloudflared
+    # Admit the synthetic uptime probe (deployment/cloudflared-probe, same
+    # cloudflare-tunnel namespace). It GETs
+    # tezca-api.tezca.svc.cluster.local:8000/health on a 60s loop and is the
+    # only thing that turns "tezca-api is down" into a page.
+    #
+    # DO NOT DELETE THIS AS REDUNDANT WITH cloudflared ABOVE. The probe pod is
+    # labelled app.kubernetes.io/name=cloudflared-probe, NOT app=cloudflared,
+    # so the peer above denies it. Denied, the probe emits `probe_blocked`
+    # every cycle forever — and a real tezca outage then looks exactly like
+    # that standing noise. The tunnel proves the public edge works; only the
+    # probe proves the Service does. Verified 2026-08-06: a raw TCP connect
+    # from the probe pod to any tezca-api pod IP on 8000 returns ECONNREFUSED
+    # (on k3s a NetworkPolicy denial rejects rather than drops), while
+    # dhanam-api and janua-api — whose namespaces admit the probe — connect.
+    #
+    # This is deliberately a SECOND ingress rule rather than a second peer
+    # inside the rule above: NetworkPolicy scopes `ports:` to the whole rule,
+    # so folding the probe into that `from` list would also clamp cloudflared
+    # to 8000 and silently blackhole the tunnel to tezca-web (3000) and
+    # tezca-admin (3001) — the same class of outage as the 2026-05-04
+    # status.enclii.dev incident this file already warns about. Separate rule
+    # ⇒ the probe is port-constrained to the API and cloudflared stays
+    # unrestricted.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare-tunnel
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudflared-probe
+      ports:
+        - protocol: TCP
+          port: 8000
 ---
 # Allow intra-namespace pod-to-pod traffic.
 #

--- a/k8s/production/tezca-api-deployment.yaml
+++ b/k8s/production/tezca-api-deployment.yaml
@@ -2,6 +2,16 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tezca-api
+  # Redundant at apply time (kustomization.yaml sets `namespace: tezca` on
+  # every resource) but load-bearing for scripts/check-networkpolicy-ports.py:
+  # it resolves a NetworkPolicy's podSelector against workloads sharing the
+  # policy's namespace, reading metadata.namespace literally with no kustomize
+  # rendering. Without this line tezca-api lands in the implicit "default"
+  # bucket, the checker sees zero containerPorts behind
+  # `app.kubernetes.io/part-of: tezca`, and any ingress rule carrying a
+  # `ports:` block fails the gate. Matches karafiel's convention, where every
+  # Deployment declares its namespace.
+  namespace: tezca
   labels:
     app.kubernetes.io/name: tezca-api
     app.kubernetes.io/part-of: tezca
@@ -118,8 +128,19 @@ spec:
               value: "redis://tezca-redis:6379/0"
             - name: ES_HOST
               value: "http://tezca-es:9200"
+            # The cluster-internal Service DNS name must stay in this list.
+            # settings.py already defaults to including it (see the
+            # "Integration Policy (Zero Touch)" comment there), but this env
+            # var OVERRIDES that default wholesale — so pinning it to the
+            # public host silently re-broke every in-cluster caller.
+            # Verified 2026-08-06 inside a tezca-api pod: GET /health with
+            # `Host: tezca-api.tezca.svc.cluster.local` returns 400
+            # DisallowedHost, while `Host: api.tezca.mx` does not. The
+            # cloudflared uptime probe derives Host from the URL and requires
+            # status 200, so without this it still reports a failure once the
+            # NetworkPolicy admits it.
             - name: ALLOWED_HOSTS
-              value: "api.tezca.mx"
+              value: "api.tezca.mx,tezca-api.tezca.svc.cluster.local"
             - name: CORS_ALLOWED_ORIGINS
               value: "https://tezca.mx,https://www.tezca.mx,https://admin.tezca.mx"
             - name: JANUA_ISSUER_URL


### PR DESCRIPTION
## What this fixes

The in-cluster synthetic uptime probe cannot reach `tezca-api`, so tezca has no working
uptime signal. Three separate blockers had to be cleared before `/health` answered; each
one masked the next.

| Blocker | Symptom | Fix |
|---|---|---|
| NetworkPolicy | connection refused | admit the probe as its own ingress rule, scoped to the API port |
| `ALLOWED_HOSTS` | `400 Bad Request` (DisallowedHost) | allow the in-cluster Service DNS name |
| `SECURE_SSL_REDIRECT` | `301` on plain HTTP | exempt `/health` from the HTTPS redirect |

With all three cleared, `GET /health` returns `200 {"status": "ok"}` — verified in-pod.

## Why the NetworkPolicy needed a second rule, not a second peer

`allow-cloudflared-ingress` admits the tunnel by pod label. The probe runs under a
different label, so it was denied.

The obvious change — adding the probe as another entry in the existing rule's `from`
array — is wrong here. In a NetworkPolicy, `ports:` applies to the whole ingress rule,
not to an individual peer. A shared rule carrying the API port would therefore also clamp
the tunnel to that one port and blackhole the web and admin surfaces, which is the
2026-05-04 outage class. `check-networkpolicy-ports.py` would not catch it: the check
passes when any listed port matches any selected pod.

A second, separate ingress rule gives both properties — the existing tunnel peer is
untouched, and the probe is constrained to the health port.

## Why the readiness probe never surfaced any of this

The kubelet sends an explicit public `Host` header and scores any 3xx as success, so it
passed while `ALLOWED_HOSTS` was rejecting the Service DNS name and the HTTPS redirect
was returning 301. Nothing was broken for users; the health endpoint was simply
unobservable from inside the cluster.

## Note on the refusal signature

The fast `ECONNREFUSED` (well under a millisecond) is the normal signature of a
NetworkPolicy denial on this CNI — it rejects rather than drops. Ruled out by direct
testing: the app is bound to `0.0.0.0:8000` with ready endpoints, so this is not a
loopback-binding problem, and it is not a missing-endpoint reject. A `DisallowedHost`
response cannot produce `ECONNREFUSED` because it arrives after a completed handshake.

## `namespace: tezca` on the API Deployment

The port-lint resolves pod selectors by reading `metadata.namespace` literally, without
kustomize rendering. With none declared, the only workload it could see behind the
`part-of` label was a CronJob with no container ports. Declaring the namespace is a no-op
at apply time and makes the check meaningful; it also turns a pre-existing warning into a
passing check.

## Verification after merge

The manifest changes take effect on sync, but the redirect exemption ships only with a
new API image, and the API deploy workflow does not trigger on `k8s/**`. Until that image
ships, expect the probe to report a failing status rather than a blocked one — which by
itself confirms the NetworkPolicy change worked. Run the API deploy workflow to close it
out, then confirm the probe reports OK.

Not yet verified end-to-end in the cluster: the post-merge path. Please re-verify rather
than assuming this is closed.

## Unrelated drift spotted

A NetworkPolicy exists live in this namespace that is not in this repo — superseded ~11
days ago and never pruned, because the deployment app ignores extraneous resources. Worth
a separate cleanup; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
